### PR TITLE
Docstring for check_noise_variance

### DIFF
--- a/hera_qm/vis_metrics.py
+++ b/hera_qm/vis_metrics.py
@@ -3,7 +3,21 @@ from hera_qm.datacontainer import DataContainer
 
 
 def check_noise_variance(data, wgts, bandwidth, inttime):
-    """XXX"""
+    '''Function to calculate the noise levels of each baseline/pol combination,
+    relative to the noise on the autos.
+
+    Args:
+        data (dict): dictionary of visibilities with keywords of pol/ant pair
+            in any order.
+        wgts (dict): dictionary of weights with keywords of pol/ant pair in any order
+        bandwidth (float): Channel width, preferably Hz, but only restriction is
+            bandwidth units are recipricol inttime units.
+        inttime (float): Integration time, preferably seconds, but only restriction
+            is inttime units are recipricol bandwidth units.
+
+    Returns:
+        Cij (dict): dictionary of variance measurements with keywords of ant pair/pol
+    '''
     dc = DataContainer(data)
     wc = DataContainer(wgts)
     Cij = {}


### PR DESCRIPTION
We currently aren't using check_noise_variance, and it needs to be updated to run with uvdata objects. But the missing docstring was preventing us from closing Issue #2.