### PR TITLE
Add ant_metrics_run.py script

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -252,7 +252,7 @@ def load_antenna_metrics(metricsJSONFile):
 
     with open(metricsJSONFile, 'r') as infile:
         jsonMetrics = json.load(infile)
-    return {key: (eval(str(val)) if key != 'version' else str(val)) for
+    return {key: (eval(str(val)) if (key != 'version' and key != 'history') else str(val)) for
             key, val in jsonMetrics.items()}
 
 
@@ -294,6 +294,7 @@ class Antenna_Metrics():
         self.dataFileList = dataFileList
         self.reds = reds
         self.version_str = hera_qm_version_str
+        self.history = ''
 
         # For using data containers until pyuvdata gets faster
         # from hera_cal import firstcal
@@ -433,12 +434,15 @@ class Antenna_Metrics():
         allMetricsData['datafile_list'] = str(self.dataFileList)
         allMetricsData['reds'] = str(self.reds)
         allMetricsData['version'] = self.version_str
+        # make sure we have something in the history string to write it out
+        if self.history != '':
+            allMetricsData['history'] = self.history
 
         with open(metricsJSONFilename, 'w') as outfile:
             json.dump(allMetricsData, outfile, indent=4)
 
 # code for running ant_metrics on a file
-def ant_metrics_run(files, opts):
+def ant_metrics_run(files, opts, history):
     """
     Run a series of ant_metrics tests on a given set of input files.
 
@@ -492,6 +496,10 @@ def ant_metrics_run(files, opts):
         am = Antenna_Metrics(jd_list, reds, fileformat=opts.vis_format)
         am.iterative_antenna_metrics_and_flagging(crossCut=opts.crossCut, deadCut=opts.deadCut,
                                                   verbose=opts.verbose)
+
+        # add history
+        am.history = am.history + history
+
         base_filename = jd_list[0]
         abspath = os.path.abspath(base_filename)
         dirname = os.path.dirname(abspath)

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -216,15 +216,17 @@ class TestAntmetricsRun(object):
         # test running with no files
         cmd = ' '.join([options, ''])
         opts, args = o.parse_args(cmd.split())
-        nt.assert_raises(AssertionError, ant_metrics.ant_metrics_run, args, opts)
+        history = cmd
+        nt.assert_raises(AssertionError, ant_metrics.ant_metrics_run, args, opts, history)
 
         # test running with a lone file
         lone_file = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA')
         cmd = ' '.join([options, lone_file])
         opts, args = o.parse_args(cmd.split())
+        history = cmd
         # this test raises a warning, then fails...
         uvtest.checkWarnings(nt.assert_raises, [
-            AssertionError, ant_metrics.ant_metrics_run, args, opts], nwarnings=1,
+            AssertionError, ant_metrics.ant_metrics_run, args, opts, history], nwarnings=1,
                              message='Could not find')
 
         # test actually running metrics
@@ -235,7 +237,8 @@ class TestAntmetricsRun(object):
             os.remove(dest_file)
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
-        ant_metrics.ant_metrics_run(args, opts)
+        history = cmd
+        ant_metrics.ant_metrics_run(args, opts, history)
         nt.assert_true(os.path.exists(dest_file))
 
 if __name__ == '__main__':

--- a/scripts/ant_metrics_run.py
+++ b/scripts/ant_metrics_run.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from hera_qm import utils
+from hera_qm import ant_metrics
+import sys
+
+o = utils.get_metrics_OptionParser('ant_metrics')
+opts, files = o.parse_args(sys.argv[1:])
+history = ' '.join(sys.argv)
+
+ant_metrics.ant_metrics_run(files, opts, history)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup_args = {
     'package_dir': {'hera_qm': 'hera_qm'},
     'packages': ['hera_qm'],
     'include_package_data': True,
-    #    'scripts': glob.glob('scripts/*'),
+    'scripts': ['scripts/ant_metrics_run.py', 'scripts/xrfi_run.py'],
     'version': version.version,
     'package_data': {'hera_qm': data_files},
     #    'install_requires': ['numpy>=1.10', 'scipy', 'pyuvdata', 'astropy>1.2', 'aipy']


### PR DESCRIPTION
This PR adds a script to call the `ant_metrics_run` function in the `ant_metrics` module. It also adds a `history` field to the JSON file saved, to keep track of the exact command called to generate the metrics.