### PR TITLE
Make changes to remove warnings from tests

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -472,7 +472,7 @@ def ant_metrics_run(files, opts, history):
     # define polarizations to look for
     if opts.pol == '':
         # default polarization list
-        pol_list = ['xx', 'xy', 'yx', 'yy']
+        pol_list = ['xx', 'yy', 'xy', 'yx']
     else:
         # assumes polarizations are passed in as comma-separated list, e.g. 'xx,xy,yx,yy'
         pol_list = opts.pol.split(',')
@@ -488,7 +488,7 @@ def ant_metrics_run(files, opts, history):
 
     # process calfile
     aa = aipy.cal.get_aa(opts.cal, freqs)
-    info = aa_to_info(aa, pols=[pol_list[-1][0]], crosspols=[pol_list[-1]])
+    info = aa_to_info(aa, pols=[pol_list[-1][0]])
     reds = info.get_reds()
 
     # do the work

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -95,9 +95,9 @@ class TestAntennaMetrics(unittest.TestCase):
 
     def setUp(self):
         self.dataFileList = [DATA_PATH + '/zen.2457698.40355.xx.HH.uvcA',
+                             DATA_PATH + '/zen.2457698.40355.yy.HH.uvcA',
                              DATA_PATH + '/zen.2457698.40355.xy.HH.uvcA',
-                             DATA_PATH + '/zen.2457698.40355.yx.HH.uvcA',
-                             DATA_PATH + '/zen.2457698.40355.yy.HH.uvcA']
+                             DATA_PATH + '/zen.2457698.40355.yx.HH.uvcA']
         if not os.path.exists(DATA_PATH + '/test_output/'):
             os.makedirs(DATA_PATH + '/test_output/')
         self.reds = [[(9, 31), (20, 65), (22, 89), (53, 96), (64, 104), (72, 81),
@@ -160,16 +160,12 @@ class TestAntennaMetrics(unittest.TestCase):
         #                                 [], fileformat='ms')
 
     def test_init(self):
-        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
-        #   for unevenly spaced polarizations. All warnings are UserWarnings
-        msg_ant = 'antenna_diameters is not set'
-        msg_pol = 'Combined polarizations are not'
-        messages = ([msg_ant]*3)
-        messages.append(msg_pol)
-        messages.append(msg_ant)
-        categories = ([UserWarning]*5)
+        # We will throw 4 warnings for unknown antenna diameters.
+        # All warnings are UserWarnings
+        messages = (['antenna_diameters is not set'] * 4)
+        categories = ([UserWarning] * 4)
         am = uvtest.checkWarnings(ant_metrics.Antenna_Metrics, [self.dataFileList, self.reds],
-                                  {"fileformat": 'miriad'}, nwarnings=5, message=messages,
+                                  {"fileformat": 'miriad'}, nwarnings=4, message=messages,
                                   category=categories)
         self.assertEqual(len(am.ants), 19)
         self.assertEqual(set(am.pols), set(['xx', 'yy', 'xy', 'yx']))
@@ -178,16 +174,12 @@ class TestAntennaMetrics(unittest.TestCase):
         self.assertEqual(len(am.reds), 27)
 
     def test_iterative_antenna_metrics_and_flagging_and_saving_and_loading(self):
-        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
-        #   for unevenly spaced polarizations. All warnings are UserWarnings
-        msg_ant = 'antenna_diameters is not set'
-        msg_pol = 'Combined polarizations are not'
-        messages = ([msg_ant]*3)
-        messages.append(msg_pol)
-        messages.append(msg_ant)
-        categories = ([UserWarning]*5)
+        # We will throw 4 warnings for unknown antenna diameters.
+        # All warnings are UserWarnings
+        messages = (['antenna_diameters is not set'] * 4)
+        categories = ([UserWarning] * 4)
         am = uvtest.checkWarnings(ant_metrics.Antenna_Metrics, [self.dataFileList, self.reds],
-                                  {"fileformat": 'miriad'}, nwarnings=5, message=messages,
+                                  {"fileformat": 'miriad'}, nwarnings=4, message=messages,
                                   category=categories)
         with self.assertRaises(KeyError):
             am.save_antenna_metrics(DATA_PATH + '/test_output/ant_metrics_output.json')
@@ -210,16 +202,12 @@ class TestAntennaMetrics(unittest.TestCase):
             self.assertEqual(loaded[jsonStat], getattr(am, stat))
 
     def test_cross_detection(self):
-        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
-        #   for unevenly spaced polarizations. All warnings are UserWarnings
-        msg_ant = 'antenna_diameters is not set'
-        msg_pol = 'Combined polarizations are not'
-        messages = ([msg_ant]*3)
-        messages.append(msg_pol)
-        messages.append(msg_ant)
-        categories = ([UserWarning]*5)
+        # We will throw 4 warnings for unknown antenna diameters.
+        # All warnings are UserWarnings
+        messages = (['antenna_diameters is not set'] * 4)
+        categories = ([UserWarning] * 4)
         am2 = uvtest.checkWarnings(ant_metrics.Antenna_Metrics, [
-            self.dataFileList, self.reds], {"fileformat": 'miriad'}, nwarnings=5,
+            self.dataFileList, self.reds], {"fileformat": 'miriad'}, nwarnings=4,
                                    message=messages, category=categories)
         am2.iterative_antenna_metrics_and_flagging(crossCut=3, deadCut=10)
         for stat in self.summaryStats:
@@ -237,7 +225,7 @@ class TestAntmetricsRun(object):
             sys.path.append(DATA_PATH)
         calfile = 'heratest_calfile'
         opt0 = "-C {}".format(calfile)
-        opt1 = "-p xx,xy,yx,yy"
+        opt1 = "-p xx,yy,xy,yx"
         opt2 = "--crossCut=5"
         opt3 = "--deadCut=5"
         opt4 = "--extension=.ant_metrics.json"
@@ -270,16 +258,12 @@ class TestAntmetricsRun(object):
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
         history = cmd
-        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
-        #   for unevenly spaced polarizations. All warnings are UserWarnings
-        msg_ant = 'antenna_diameters is not set'
-        msg_pol = 'Combined polarizations are not'
-        messages = ([msg_ant]*3)
-        messages.append(msg_pol)
-        messages.append(msg_ant)
-        categories = ([UserWarning]*5)
+        # We will throw 4 warnings for unknown antenna diameters.
+        # All warnings are UserWarnings
+        messages = (['antenna_diameters is not set'] * 4)
+        categories = ([UserWarning] * 4)
         uvtest.checkWarnings(ant_metrics.ant_metrics_run, [args, opts, history],
-                             nwarnings=5, message=messages, category=categories)
+                             nwarnings=4, message=messages, category=categories)
         nt.assert_true(os.path.exists(dest_file))
 
 if __name__ == '__main__':

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -141,8 +141,10 @@ class TestAntennaMetrics(unittest.TestCase):
 
     def test_load_errors(self):
         with self.assertRaises(ValueError):
-            ant_metrics.Antenna_Metrics([DATA_PATH + '/zen.2457698.40355.xx.HH.uvcA'],
-                                        [], fileformat='miriad')
+            uvtest.checkWarnings(ant_metrics.Antenna_Metrics,
+                                 [[DATA_PATH + '/zen.2457698.40355.xx.HH.uvcA'], []],
+                                 {"fileformat": 'miriad'}, nwarnings=1,
+                                 message='antenna_diameters is not set')
         with self.assertRaises(IOError):
             ant_metrics.Antenna_Metrics([DATA_PATH + '/zen.2457698.40355.xx.HH.uvcA'],
                                         [], fileformat='uvfits')
@@ -158,7 +160,17 @@ class TestAntennaMetrics(unittest.TestCase):
         #                                 [], fileformat='ms')
 
     def test_init(self):
-        am = ant_metrics.Antenna_Metrics(self.dataFileList, self.reds, fileformat='miriad')
+        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
+        #   for unevenly spaced polarizations. All warnings are UserWarnings
+        msg_ant = 'antenna_diameters is not set'
+        msg_pol = 'Combined polarizations are not'
+        messages = ([msg_ant]*3)
+        messages.append(msg_pol)
+        messages.append(msg_ant)
+        categories = ([UserWarning]*5)
+        am = uvtest.checkWarnings(ant_metrics.Antenna_Metrics, [self.dataFileList, self.reds],
+                                  {"fileformat": 'miriad'}, nwarnings=5, message=messages,
+                                  category=categories)
         self.assertEqual(len(am.ants), 19)
         self.assertEqual(set(am.pols), set(['xx', 'yy', 'xy', 'yx']))
         self.assertEqual(set(am.antpols), set(['x', 'y']))
@@ -166,7 +178,17 @@ class TestAntennaMetrics(unittest.TestCase):
         self.assertEqual(len(am.reds), 27)
 
     def test_iterative_antenna_metrics_and_flagging_and_saving_and_loading(self):
-        am = ant_metrics.Antenna_Metrics(self.dataFileList, self.reds, fileformat='miriad')
+        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
+        #   for unevenly spaced polarizations. All warnings are UserWarnings
+        msg_ant = 'antenna_diameters is not set'
+        msg_pol = 'Combined polarizations are not'
+        messages = ([msg_ant]*3)
+        messages.append(msg_pol)
+        messages.append(msg_ant)
+        categories = ([UserWarning]*5)
+        am = uvtest.checkWarnings(ant_metrics.Antenna_Metrics, [self.dataFileList, self.reds],
+                                  {"fileformat": 'miriad'}, nwarnings=5, message=messages,
+                                  category=categories)
         with self.assertRaises(KeyError):
             am.save_antenna_metrics(DATA_PATH + '/test_output/ant_metrics_output.json')
 
@@ -188,7 +210,17 @@ class TestAntennaMetrics(unittest.TestCase):
             self.assertEqual(loaded[jsonStat], getattr(am, stat))
 
     def test_cross_detection(self):
-        am2 = ant_metrics.Antenna_Metrics(self.dataFileList, self.reds, fileformat='miriad')
+        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
+        #   for unevenly spaced polarizations. All warnings are UserWarnings
+        msg_ant = 'antenna_diameters is not set'
+        msg_pol = 'Combined polarizations are not'
+        messages = ([msg_ant]*3)
+        messages.append(msg_pol)
+        messages.append(msg_ant)
+        categories = ([UserWarning]*5)
+        am2 = uvtest.checkWarnings(ant_metrics.Antenna_Metrics, [
+            self.dataFileList, self.reds], {"fileformat": 'miriad'}, nwarnings=5,
+                                   message=messages, category=categories)
         am2.iterative_antenna_metrics_and_flagging(crossCut=3, deadCut=10)
         for stat in self.summaryStats:
             self.assertTrue(hasattr(am2, stat))
@@ -238,7 +270,16 @@ class TestAntmetricsRun(object):
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
         history = cmd
-        ant_metrics.ant_metrics_run(args, opts, history)
+        # We will throw 5 total warnings: 4 for unknown antenna diameters, and one
+        #   for unevenly spaced polarizations. All warnings are UserWarnings
+        msg_ant = 'antenna_diameters is not set'
+        msg_pol = 'Combined polarizations are not'
+        messages = ([msg_ant]*3)
+        messages.append(msg_pol)
+        messages.append(msg_ant)
+        categories = ([UserWarning]*5)
+        uvtest.checkWarnings(ant_metrics.ant_metrics_run, [args, opts, history],
+                             nwarnings=5, message=messages, category=categories)
         nt.assert_true(os.path.exists(dest_file))
 
 if __name__ == '__main__':

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -8,6 +8,7 @@ import numpy as np
 import pylab as plt
 import hera_qm.tests as qmtest
 from inspect import getargspec
+import pyuvdata.tests as uvtest
 import hera_qm.utils as utils
 from hera_qm.data import DATA_PATH
 
@@ -311,7 +312,8 @@ class TestXrfiRun(object):
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
         history = cmd
-        xrfi.xrfi_run(args, opts, cmd)
+        uvtest.checkWarnings(xrfi.xrfi_run, [args, opts, cmd], nwarnings=1,
+                             message='antenna_diameters is not set')
         nt.assert_true(os.path.exists(dest_file))
 
     def test_xrfi_run_xrfi_simple(self):
@@ -339,7 +341,8 @@ class TestXrfiRun(object):
             shutil.rmtree(dest_file)
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
-        xrfi.xrfi_run(args, opts, cmd)
+        uvtest.checkWarnings(xrfi.xrfi_run, [args, opts, cmd], nwarnings=1,
+                             message='antenna_diameters is not set')
         nt.assert_true(os.path.exists(dest_file))
 
     def test_xrfi_run_errors(self):
@@ -373,7 +376,8 @@ class TestXrfiRun(object):
         options = ' '.join([opt0, opt1])
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
-        nt.assert_raises(ValueError, xrfi.xrfi_run, args, opts, cmd)
+        uvtest.checkWarnings(nt.assert_raises, [ValueError, xrfi.xrfi_run, args, opts, cmd],
+                             nwarnings=1, message='antenna_diamters is not set')
 
         # choose an invalid output format
         opt0 = "--infile_format=miriad"
@@ -383,7 +387,8 @@ class TestXrfiRun(object):
         xx_file = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA')
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
-        nt.assert_raises(ValueError, xrfi.xrfi_run, args, opts, cmd)
+        uvtest.checkWarnings(nt.assert_raises, [ValueError, xrfi.xrfi_run, args, opts, cmd],
+                             nwarnings=1, message='antenna_diameters is not set')
 
     def test_xrfi_run_output_options(self):
         # test different output options
@@ -402,7 +407,8 @@ class TestXrfiRun(object):
             os.remove(dest_file)
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
-        xrfi.xrfi_run(args, opts, cmd)
+        uvtest.checkWarnings(xrfi.xrfi_run, [args, opts, cmd], nwarnings=1,
+                             message='antenna_diamteters is not set')
         nt.assert_true(os.path.exists(dest_file))
 
         # test writing to same directory
@@ -417,7 +423,8 @@ class TestXrfiRun(object):
             shutil.rmtree(dest_file)
         cmd = ' '.join([options, xx_file])
         opts, args = o.parse_args(cmd.split())
-        xrfi.xrfi_run(args, opts, cmd)
+        uvtest.checkWarnings(xrfi.xrfi_run, [args, opts, cmd], nwarnings=1,
+                             message='antenna_diameters is not set')
         nt.assert_true(os.path.exists(dest_file))
         # clean up
         shutil.rmtree(dest_file)

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -72,7 +72,7 @@ def detrend_deriv(d, dt=True, df=True):
     sig_t = np.median(d2, axis=1)
     sig_t.shape = (-1, 1)
     sig = np.sqrt(sig_f * sig_t / np.median(sig_t))
-    return d_dt / sig
+    return np.divide(d_dt, sig, where=(np.abs(sig) > 1e-7))
 
 
 def detrend_medminfilt(d, Kt=8, Kf=8):
@@ -89,7 +89,8 @@ def detrend_medminfilt(d, Kt=8, Kf=8):
     d_sq = np.abs(d_rs)**2
     # puts minmed on same scale as average
     sig = np.sqrt(medminfilt(d_sq, 2 * Kt + 1, 2 * Kf + 1)) * (np.sqrt(Kt**2 + Kf**2) / .64)
-    f = d_rs / sig
+    # take care not to divide by zero
+    f = np.divide(d_rs, sig, where=(np.abs(sig) > 1e-7))
     return f
 
 
@@ -110,7 +111,8 @@ def detrend_medfilt(d, Kt=8, Kf=8):
     d_sq = np.abs(d_rs)**2
     # puts median on same scale as average
     sig = np.sqrt(medfilt(d_sq, kernel_size=(2 * Kt + 1, 2 * Kf + 1)) / .456)
-    f = d_rs / sig
+    # take care not to divide by zero
+    f = np.divide(d_rs, sig, where=(np.abs(sig) > 1e-7))
     return f[Kt:-Kt, Kf:-Kf]
 
 

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -72,7 +72,10 @@ def detrend_deriv(d, dt=True, df=True):
     sig_t = np.median(d2, axis=1)
     sig_t.shape = (-1, 1)
     sig = np.sqrt(sig_f * sig_t / np.median(sig_t))
-    return np.divide(d_dt, sig, where=(np.abs(sig) > 1e-7))
+    # don't divide by zero, instead turn those entries into +inf
+    f = np.true_divide(d_dt, sig, where=(np.abs(sig) > 1e-7))
+    f = np.where(np.abs(sig) > 1e-7, f, np.inf)
+    return f
 
 
 def detrend_medminfilt(d, Kt=8, Kf=8):
@@ -89,8 +92,9 @@ def detrend_medminfilt(d, Kt=8, Kf=8):
     d_sq = np.abs(d_rs)**2
     # puts minmed on same scale as average
     sig = np.sqrt(medminfilt(d_sq, 2 * Kt + 1, 2 * Kf + 1)) * (np.sqrt(Kt**2 + Kf**2) / .64)
-    # take care not to divide by zero
-    f = np.divide(d_rs, sig, where=(np.abs(sig) > 1e-7))
+    # don't divide by zero, instead turn those entries into +inf
+    f = np.true_divide(d_rs, sig, where=(np.abs(sig) > 1e-7))
+    f = np.where(np.abs(sig) > 1e-7, f, np.inf)
     return f
 
 
@@ -111,8 +115,9 @@ def detrend_medfilt(d, Kt=8, Kf=8):
     d_sq = np.abs(d_rs)**2
     # puts median on same scale as average
     sig = np.sqrt(medfilt(d_sq, kernel_size=(2 * Kt + 1, 2 * Kf + 1)) / .456)
-    # take care not to divide by zero
-    f = np.divide(d_rs, sig, where=(np.abs(sig) > 1e-7))
+    # don't divide by zero, instead turn those entries into +inf
+    f = np.true_divide(d_rs, sig, where=(np.abs(sig) > 1e-7))
+    f = np.where(np.abs(sig) > 1e-7, f, np.inf)
     return f[Kt:-Kt, Kf:-Kf]
 
 


### PR DESCRIPTION
This PR addresses Issue #24. A substantive change in several `xrfi` functions was introduced to prevent division by zero as well.