### PR TITLE
Remove ms support

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -283,8 +283,6 @@ class Antenna_Metrics():
             self.data.read_uvfits(dataFileList)
         elif fileformat == 'fhd':
             self.data.read_fhd(dataFileList)
-        elif fileformat == 'ms':
-            self.data.read_ms(dataFileList)
         else:
             raise ValueError('Unrecognized file format ' + str(fileformat))
         self.ants = self.data.get_ants()

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -154,10 +154,6 @@ class TestAntennaMetrics(unittest.TestCase):
         with self.assertRaises(ValueError):
             ant_metrics.Antenna_Metrics([DATA_PATH + '/zen.2457698.40355.xx.HH.uvcA'],
                                         [], fileformat='not_a_format')
-        # if casacore is not installed, this test raises a skiptest
-        # with self.assertRaises(IOError):
-        #     ant_metrics.Antenna_Metrics([DATA_PATH + '/zen.2457698.40355.xx.HH.uvcA'],
-        #                                 [], fileformat='ms')
 
     def test_init(self):
         # We will throw 4 warnings for unknown antenna diameters.

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -360,11 +360,6 @@ class TestXrfiRun(object):
         opts, args = o.parse_args(cmd.split())
         nt.assert_raises(StandardError, xrfi.xrfi_run, args, opts, cmd)
 
-        opt0 = "--infile_format=ms"
-        cmd = ' '.join([opt0, xx_file])
-        opts, args = o.parse_args(cmd.split())
-        nt.assert_raises(RuntimeError, xrfi.xrfi_run, args, opts, cmd)
-
         opt0 = "--infile_format=blah"
         cmd = ' '.join([opt0, xx_file])
         opts, args = o.parse_args(cmd.split())

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -244,8 +244,6 @@ def xrfi_run(files, opts, history):
             uvd.read_uvfits(fn)
         elif opts.infile_format == 'fhd':
             uvd.read_fhd(fn)
-        elif opts.infile_format == 'ms':
-            uvd.read_ms(fn)
         else:
             raise ValueError('Unrecognized input file format ' + str(opts.infile_format))
 


### PR DESCRIPTION
Though `pyuvdata` supports reading CASA measurement sets, we need not provide this functionality, since we are working specifically with HERA data. As a practical matter, testing this would require installing `casacore`, or having untested code. Both solutions are suboptimal, and so we are removing this support for the time being. If users require this functionality in the future, we can reintroduce it.