### PR TITLE
Mild import cleanup

### DIFF
--- a/hera_qm/__init__.py
+++ b/hera_qm/__init__.py
@@ -1,6 +1,4 @@
 """init file for hera_qm."""
-# import vis_metrics
-# import cal_metrics
 import xrfi
 import vis_metrics
 import ant_metrics

--- a/hera_qm/firstcal_metrics.py
+++ b/hera_qm/firstcal_metrics.py
@@ -1,7 +1,6 @@
 """
 FirstCal metrics
 """
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from pyuvdata import UVCal

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 import os
-from scipy.signal import medfilt
 from pyuvdata import UVData
 
 #############################################################################
@@ -106,6 +105,9 @@ def detrend_medfilt(d, Kt=8, Kf=8):
     Returns:
         bool array: boolean array of flags
     """
+    # Delay import so scipy is not required for any use of hera_qm
+    from scipy.signal import medfilt
+
     if Kt > d.shape[0] or Kf > d.shape[1]:
         raise ValueError('Kernel size exceeds data.')
     d = np.concatenate([d[Kt - 1::-1], d, d[:-Kt - 1:-1]], axis=0)


### PR DESCRIPTION
The biggest change is that inside xrfi I moved the scipy import into a function so that other packages which use hera_qm (e.g. hera_mc) don't need scipy if they are using other functionality.