### PR TITLE
Sklearn compatability with hera_qm

### DIFF
--- a/hera_qm/firstcal_metrics.py
+++ b/hera_qm/firstcal_metrics.py
@@ -17,7 +17,7 @@ try:
     from sklearn import gaussian_process as gp
     sklearn_import = True
 except ImportError:
-    raise Warning("Could not import sklearn")
+    print "could not import sklearn"
     sklearn_import = False
 
 


### PR DESCRIPTION
failed sklearn import no longer raises a warning, but prints "could not import sklearn"