### PR TITLE
Add ex_ants options

### DIFF
--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -121,6 +121,12 @@ def get_metrics_ArgumentParser(method_name):
         a.add_argument('--time_threshold', default=0.05, type=float,
                        help='Fraction of times required to trigger broadcast across'
                        ' time (single frequency). Default is 0.05.')
+        a.add_argument('--ex_ants', default='', type=str,
+                       help='Comma-separated list of antennas to exclude. Flags of visibilities '
+                       'formed with these antennas will be set to True.')
+        a.add_argument('--metrics_json', default='', type=str,
+                       help='Metrics file that contains a list of excluded antennas. Flags of '
+                       'visibilities formed with these antennas will be set to True.')
         a.add_argument('filename', metavar='filename', nargs='*', type=str, default=[],
                        help='file for which to flag RFI (only one file allowed).')
     elif method_name == 'xrfi_apply':


### PR DESCRIPTION
This PR adds an `ex_ants` and `metrics_json` command line options, similar to those in `omni_run` from hera_cal. `ex_ants` allows the user to specify a comma-separated list of antennas to exclude from RFI threshold calculations, and `metrics_json` allows the user to pass in a JSON file, where it is assumed one of the dictionary keys is `ex_ants`. The visibilities corresponding to these antennas are flagged in the specified visibility before the xrfi flagging algorithm is run, and so the flags are normalized out in thresholding calculations.

One drawback of this approach is that this functionality is added to `xrfi_run`, and as such, the flags are _not_ saved back out to the input visibility file. If that functionality is desired, I think we should add that in the `xrfi_apply` step, which is a more natural spot for it. I could add that in without too much trouble, but thought I'd make the PR now to see what other people think.