### PR TITLE
Fix watershed bug

### DIFF
--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -185,8 +185,8 @@ def watershed_flag(d, f=None, sig_init=6, sig_adj=2):
     prevx, prevy = 0, 0
     x, y = np.where(f1.mask)
     while x.size != prevx and y.size != prevy:
+        prevx, prevy = x.size, y.size
         for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
-            prevx, prevy = x.size, y.size
             xp, yp = (x + dx).clip(0, f1.shape[0] - 1), (y + dy).clip(0, f1.shape[1] - 1)
             i = np.where(f1[xp, yp] > sig_adj)[0]  # if sigma > 'sigl'
             f1.mask[xp[i], yp[i]] = 1


### PR DESCRIPTION
This PR addresses Issue #107. In the `watershed_flag` function, the watershed terminates when no flags are added for adjacent points in time/frequency space in a given iteration. As previously written, the watershed might incorrectly terminate early, where another iteration would be triggered only if flags are added in the negative-y direction (rather than any direction).

A crucial test that should be done is testing this fix on data to make sure that this doesn't break things catastrophically. Once that is done, this is likely a "critical bug fix" that should be incorporated in the H1C branch.