### PR TITLE
Fix to watershed algorithm when looking for outliers next to flagged channels.

### DIFF
--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -901,17 +901,18 @@ class TestFlagXants(object):
                 flags = uv.flag_array[blts, :, :, :]
                 nt.assert_true(np.allclose(flags, True))
 
+
 class TestInputFlagWatershed(object):
     def test_input_flag(self):
         # create some fake data for input to watershed
-        SIZE=10
+        SIZE = 10
         sigmas = np.ones((SIZE, SIZE))
         sigmas[:, 3] = 7
         sigmas[1::2, 5:7] = 3
         # create some input flags
         input_flags = np.zeros((SIZE, SIZE), dtype=bool)
         input_flags[:, 4] = 1
-        
+
         # flag using watershed
         w_input_flags = xrfi.watershed_flag(sigmas, f=input_flags)
 
@@ -919,9 +920,9 @@ class TestInputFlagWatershed(object):
         flag_check = np.zeros((SIZE, SIZE), dtype=bool)
         flag_check[:, 3:4] = 1
         flag_check[1::2, 5:7] = 1
-        
-        nt.assert_equal(w_input_flags, flag_check)
-        
+
+        nt.assert_true(np.all(w_input_flags == flag_check))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -901,5 +901,27 @@ class TestFlagXants(object):
                 flags = uv.flag_array[blts, :, :, :]
                 nt.assert_true(np.allclose(flags, True))
 
+class TestInputFlagWatershed(object):
+    def test_input_flag(self):
+        # create some fake data for input to watershed
+        SIZE=10
+        sigmas = np.ones((SIZE, SIZE))
+        sigmas[:, 3] = 7
+        sigmas[1::2, 5:7] = 3
+        # create some input flags
+        input_flags = np.zeros((SIZE, SIZE), dtype=bool)
+        input_flags[:, 4] = 1
+        
+        # flag using watershed
+        w_input_flags = xrfi.watershed_flag(sigmas, f=input_flags)
+
+        # create array to test against
+        flag_check = np.zeros((SIZE, SIZE), dtype=bool)
+        flag_check[:, 3:4] = 1
+        flag_check[1::2, 5:7] = 1
+        
+        nt.assert_equal(w_input_flags, flag_check)
+        
+
 if __name__ == '__main__':
     unittest.main()

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -918,9 +918,8 @@ class TestInputFlagWatershed(object):
 
         # create array to test against
         flag_check = np.zeros((SIZE, SIZE), dtype=bool)
-        flag_check[:, 3:4] = 1
+        flag_check[:, 3:5] = 1
         flag_check[1::2, 5:7] = 1
-
         nt.assert_true(np.all(w_input_flags == flag_check))
 
 

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -188,7 +188,7 @@ def watershed_flag(d, f=None, sig_init=6, sig_adj=2):
         prevx, prevy = x.size, y.size
         for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
             xp, yp = (x + dx).clip(0, f1.shape[0] - 1), (y + dy).clip(0, f1.shape[1] - 1)
-            i = np.where(f1[xp, yp] > sig_adj)[0]  # if sigma > 'sigl'
+            i = np.where(d[xp, yp] > sig_adj)[0]  # if sigma > 'sigl'
             f1.mask[xp[i], yp[i]] = 1
             x, y = np.where(f1.mask)
     return f1.mask


### PR DESCRIPTION
In my attempts to RFI flag I found a bug in the watershed algorithm as written. Once the main flags have been found, it looked like the flagging of possible RFI next to neighboring channels was not working well. It was mistakenly using flags as the sigma array instead of the actual sigma array when comparing to sig_adj. If sig_adj = 1, nothing changes, but any other value would over or underestimate the flag array. 