### PR TITLE
Support reading metrics files with inf values

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -289,7 +289,7 @@ def load_antenna_metrics(metricsJSONFile):
 
     with open(metricsJSONFile, 'r') as infile:
         jsonMetrics = json.load(infile)
-    gvars = {'nan': np.nan}
+    gvars = {'nan': np.nan, 'inf': np.inf, '-inf': -np.inf}
     return {key: (eval(str(val), gvars) if (key != 'version' and key != 'history') else str(val)) for
             key, val in jsonMetrics.items()}
 


### PR DESCRIPTION
This PR supports reading `inf` values saved in metrics files. Right now they break the file reader, and we should support loading them (even if they signify bad data or incorrect processing). This also introduces a test specifically for the `load_antenna_metrics` function.