### PR TITLE
Allow for antennas in cminfo that are not in file

### DIFF
--- a/scripts/auto_view.py
+++ b/scripts/auto_view.py
@@ -101,8 +101,12 @@ antpos = np.zeros((np.max(ants) + 1, 2))
 ants_connected = []
 antnames = ["" for x in range(np.max(ants) + 1)]
 for stn in stations_conn:
+    # make sure that antenna in cminfo is in data file
+    try:
+        antpos[stn['antenna_number'], :] = [stn['easting'], stn['northing']]
+    except IndexError:
+        continue
     ants_connected.append(stn['antenna_number'])
-    antpos[stn['antenna_number'], :] = [stn['easting'], stn['northing']]
     antnames[stn['antenna_number']] = stn['station_name']
 array_center = np.mean(antpos[antpos[:, 0] != 0, :], axis=0)
 antpos -= array_center


### PR DESCRIPTION
This PR changes `auto_view.py` to allow for cases where an antenna is deemed "hooked up" at the time of the file, but is not present in the data file itself. Reasons for this mismatch are the db being updated after the start of observation, but before the conclusion (since the `cminfo` is only pulled at the start of observing by the correlator), or the `hera_mc` repo on `paper1` not being up to date. An essentially similar fix has been deployed on-site, and appears to be working as part of RTP.