### PR TITLE
Xrfi after delay filter

### DIFF
--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -10,6 +10,7 @@ import pylab as plt
 import hera_qm.tests as qmtest
 from inspect import getargspec
 import pyuvdata.tests as uvtest
+from pyuvdata import UVData
 import hera_qm.utils as utils
 from hera_qm.data import DATA_PATH
 
@@ -342,6 +343,20 @@ class TestXrfiRun(object):
         nt.assert_true(os.path.exists(dest_file))
         os.remove(dest_file)
 
+        # test running with UVData object
+        uv = UVData()
+        uv.read_miriad(xx_file)
+        if os.path.exists(dest_file):
+            os.remove(dest_file)
+        xrfi.xrfi_run(uv, args, cmd)
+        nt.assert_true(os.path.exists(dest_file))
+        os.remove(dest_file)
+
+        # Test missing filename
+        cmd = ' '.join([arguments])
+        args = a.parse_args(cmd.split())
+        nt.assert_raises(AssertionError, xrfi.xrfi_run, uv, args, cmd)
+
     def test_xrfi_run_xrfi_simple(self):
         # get argument object
         a = utils.get_metrics_ArgumentParser('xrfi_run')
@@ -377,7 +392,6 @@ class TestXrfiRun(object):
         os.remove(sum_file)
 
     def test_xrfi_run_model_and_cal(self):
-        from pyuvdata import UVData
 
         # get argument object
         a = utils.get_metrics_ArgumentParser('xrfi_run')
@@ -429,7 +443,6 @@ class TestXrfiRun(object):
         shutil.rmtree(model_file)
 
     def test_xrfi_run_model_and_cal_errors(self):
-        from pyuvdata import UVData
 
         # get argument object
         a = utils.get_metrics_ArgumentParser('xrfi_run')
@@ -656,7 +669,6 @@ class TestXrfiApply(object):
 class TestSummary(unittest.TestCase):
     def test_summarize_flags(self):
         from hera_qm.version import hera_qm_version_str
-        from pyuvdata import UVData
 
         infile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA')
         uv = UVData()
@@ -689,7 +701,6 @@ class TestSummary(unittest.TestCase):
         os.remove(outfile)  # cleanup
 
     def test_summarize_flags_with_prior(self):
-        from pyuvdata import UVData
 
         infile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA')
         uv = UVData()
@@ -712,7 +723,6 @@ class TestSummary(unittest.TestCase):
 
 class TestVisFlag(object):
     def test_vis_flag(self):
-        from pyuvdata import UVData
 
         a = utils.get_metrics_ArgumentParser('xrfi_run')
         args = a.parse_args([''])
@@ -787,7 +797,6 @@ class TestCalFlag(object):
 
 class TestFlags2Waterfall(object):
     def test_flags2waterfall(self):
-        from pyuvdata import UVData
         from pyuvdata import UVCal
 
         uv = UVData()
@@ -808,7 +817,6 @@ class TestFlags2Waterfall(object):
         nt.assert_equal(wf.shape, (uvc.Ntimes, uvc.Nfreqs))
 
     def test_flags2waterfall_errors(self):
-        from pyuvdata import UVData
 
         # First argument must be UVData or UVCal object
         nt.assert_raises(ValueError, xrfi.flags2waterfall, 5)
@@ -821,7 +829,6 @@ class TestFlags2Waterfall(object):
 
 class TestWaterfall2Flags(object):
     def test_waterfall2flags(self):
-        from pyuvdata import UVData
         from pyuvdata import UVCal
 
         uv = UVData()
@@ -845,7 +852,6 @@ class TestWaterfall2Flags(object):
             nt.assert_true(np.all(wf == flags[ai, 0, :, :, 0].T))
 
     def test_waterfall2flags_errors(self):
-        from pyuvdata import UVData
 
         uv = UVData()
         uv.read_uvfits(os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.vis.uvfits'))
@@ -881,7 +887,6 @@ class TestFlagXants(object):
         nt.assert_raises(ValueError, xrfi.flag_xants, 7, [0])
 
         # Read in a data file and flag some antennas
-        from pyuvdata import UVData
         infile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA')
         uv = UVData()
         uv.read_miriad(infile)

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -150,7 +150,9 @@ def get_metrics_ArgumentParser(method_name):
                        'list of npz files containing waterfalls of flags to broadcast '
                        'to full flag array and union with flag array in flag_file.')
         a.add_argument('--output_npz', default=True, type=bool,
-                       help='Whether to save an npz with the final flag array and waterfall.')
+                       help='Whether to save an npz with the final flag array and waterfall. '
+                       'The flag array will be identical to what is stored in the data, '
+                       'and the waterfall is the union of all input waterfalls.')
         a.add_argument('--out_npz_ext', default='.flags.npz', type=str,
                        help='Extension to be appended to input file name. Default is ".flags.npz".')
         a.add_argument('filename', metavar='filename', nargs='*', type=str, default=[],

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -149,6 +149,10 @@ def get_metrics_ArgumentParser(method_name):
         a.add_argument('--waterfalls', default=None, type=str, help='comma separated '
                        'list of npz files containing waterfalls of flags to broadcast '
                        'to full flag array and union with flag array in flag_file.')
+        a.add_argument('--output_npz', default=True, type=bool,
+                       help='Whether to save an npz with the final flag array and waterfall.')
+        a.add_argument('--out_npz_ext', default='.flags.npz', type=str,
+                       help='Extension to be appended to input file name. Default is ".flags.npz".')
         a.add_argument('filename', metavar='filename', nargs='*', type=str, default=[],
                        help='file for which to flag RFI (only one file allowed).')
     return a

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -249,37 +249,44 @@ def xrfi(d, f=None, Kt=8, Kf=8, sig_init=6, sig_adj=2):
     return f
 
 
-def xrfi_run(filename, args, history):
+def xrfi_run(indata, args, history):
     """
     Run an RFI-flagging algorithm on a single data file, and optionally calibration files,
     and store results in npz files.
 
     Args:
-       filename -- Data file to run RFI flagging on.
+       indata -- Either UVData object or data file to run RFI flagging on.
        args -- parsed arguments via argparse.ArgumentParser.parse_args
        history -- history string to include in files
     Return:
        None
 
-    This function will take in a data file and optionally a cal file and
+    This function will take in a UVData object or  data file and optionally a cal file and
     model visibility file, and run an RFI-flagging algorithm to identify contaminated
     observations. Each set of flagging will be stored, as well as compressed versions.
     """
-    # make sure we were given files to process
-    if len(filename) == 0:
-        raise AssertionError('Please provide a visibility file')
-    if len(filename) > 1:
-        raise AssertionError('xrfi_run currently only takes a single data file.')
-    filename = filename[0]
-    uvd = UVData()
-    if args.infile_format == 'miriad':
-        uvd.read_miriad(filename)
-    elif args.infile_format == 'uvfits':
-        uvd.read_uvfits(filename)
-    elif args.infile_format == 'fhd':
-        uvd.read_fhd(filename)
+    if isinstance(indata, UVData):
+        uvd = indata
+        if len(args.filename) == 0:
+            raise AssertionError('Please provide a filename to go with UVData object.')
+        else:
+            filename = args.filename[0]
     else:
-        raise ValueError('Unrecognized input file format ' + str(args.infile_format))
+        # make sure we were given files to process
+        if len(indata) == 0:
+            raise AssertionError('Please provide a visibility file or UVData object')
+        if len(indata) > 1:
+            raise AssertionError('xrfi_run currently only takes a single data file.')
+        filename = indata[0]
+        uvd = UVData()
+        if args.infile_format == 'miriad':
+            uvd.read_miriad(filename)
+        elif args.infile_format == 'uvfits':
+            uvd.read_uvfits(filename)
+        elif args.infile_format == 'fhd':
+            uvd.read_fhd(filename)
+        else:
+            raise ValueError('Unrecognized input file format ' + str(args.infile_format))
 
     # Compute list of excluded antennas
     if args.ex_ants != '' or args.metrics_json != '':

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -268,7 +268,9 @@ def xrfi_run(indata, args, history):
     if isinstance(indata, UVData):
         uvd = indata
         if len(args.filename) == 0:
-            raise AssertionError('Please provide a filename to go with UVData object.')
+            raise AssertionError('Please provide a filename to go with UVData object. '
+                                 'The filename is used in conjunction with "extension" '
+                                 'to determine the output filename.')
         else:
             filename = args.filename[0]
     else:
@@ -678,6 +680,8 @@ def xrfi_apply(filename, args, history):
     if len(waterfalls) > 0:
         wf_full = sum(waterfalls).astype(bool)  # Union all waterfalls
         flag_array += waterfall2flags(wf_full, uvd)  # Combine with flag array
+    else:
+        wf_full = None
 
     # Finally, add the flag array to the flag array in the data
     uvd.flag_array += flag_array
@@ -705,4 +709,5 @@ def xrfi_apply(filename, args, history):
     if args.output_npz:
         # Save an npz with the final flag array and waterfall
         outpath = outpath + args.out_npz_ext
-        np.savez(outpath, flag_array=uvd.flag_array, history=flag_history + history)
+        np.savez(outpath, flag_array=uvd.flag_array, waterfall=wf_full,
+                 history=flag_history + history)

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -702,3 +702,7 @@ def xrfi_apply(filename, args, history):
         uvd.write_uvfits(outpath, force_phase=True, spoof_nonessential=True)
     else:
         raise ValueError('Unrecognized output file format ' + str(args.outfile_format))
+    if args.output_npz:
+        # Save an npz with the final flag array and waterfall
+        outpath = outpath + args.out_npz_ext
+        np.savez(outpath, flag_array=uvd.flag_array, history=flag_history + history)

--- a/scripts/delay_xrfi_run.py
+++ b/scripts/delay_xrfi_run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import sys
+from hera_qm import utils as qm_utils
+from hera_cal import utils as cal_utils
+from hera_qm import xrfi
+from hera_cal import delay_filter
+from hera_cal import io
+
+ax = qm_utils.get_metrics_ArgumentParser('xrfi_run')
+ad = cal_utils.get_cal_ArgumentParser('delay_filter')
+args_x = ax.parse_known_args()
+args_d = ad.parse_known_args()
+filename = args_x.filename
+history = ' '.join(sys.argv)
+
+# Read data, apply delay filter, update UVData object
+dfil = delay_filter.Delay_Filter()
+uv = UVData()
+uv.read_miriad(filename)
+dfil.load_data(uv)
+dfil.run_filter(standoff=args_d.standoff, horizon=args_d.horizon, tol=args_d.tol,
+                window=args_d.window, skip_wgt=args_d.skip_wgt, maxiter=args_d.maxiter)
+io.update_uvdata(dfil.input_data, data=dfil.filtered_residuals)
+
+# Run xrfi
+xrfi.xrfi_run(dfil.input_data, args_x, history)

--- a/scripts/delay_xrfi_run.py
+++ b/scripts/delay_xrfi_run.py
@@ -2,13 +2,12 @@
 
 import sys
 from hera_qm import utils as qm_utils
-from hera_cal import utils as cal_utils
 from hera_qm import xrfi
 from hera_cal import delay_filter
 from hera_cal import io
 
 ax = qm_utils.get_metrics_ArgumentParser('xrfi_run')
-ad = cal_utils.get_cal_ArgumentParser('delay_filter')
+ad = delay_filter.delay_filter_argparser()
 args_x = ax.parse_known_args()
 args_d = ad.parse_known_args()
 filename = args_x.filename


### PR DESCRIPTION
This PR enables the delay_xrfi_run script which does a delay filter before rfi flagging. It does a few things:
- allows a UVData object to be passed to xrfi_run
- adds an output npz in xrfi_apply to save the flags actually applied to the data (separately)
- creates the delay_xrfi_run script