### PR TITLE
Delay xrfi a priori flags

### DIFF
--- a/hera_qm/tests/test_utils.py
+++ b/hera_qm/tests/test_utils.py
@@ -53,6 +53,21 @@ def test_get_metrics_ArgumentParser():
     # raise error for requesting unknown type of parser
     nt.assert_raises(AssertionError, utils.get_metrics_ArgumentParser, 'fake_method')
 
+    # Test the delay_xrfi_run method
+    a = utils.get_metrics_ArgumentParser('delay_xrfi_run')
+    # First try defaults - test a few of them
+    args = a.parse_args('')
+    nt.assert_equal(args.infile_format, 'miriad')
+    nt.assert_equal(args.algorithm, 'xrfi_simple')
+    nt.assert_equal(args.nsig_dt, 6.0)
+    nt.assert_equal(args.px_threshold, 0.2)
+    nt.assert_equal(args.filename, None)
+    nt.assert_equal(args.tol, 1e-5)
+    nt.assert_equal(args.waterfalls, None)
+    # try to set something
+    args = a.parse_args(['--waterfalls', 'a,g'])
+    nt.assert_equal(args.waterfalls, 'a,g')
+
 
 def test_metrics2mc():
     # test ant metrics

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -325,6 +325,9 @@ class TestXrfiRun(object):
         history = cmd
         nt.assert_raises(AssertionError, xrfi.xrfi_run, args.filename, args, history)
 
+        # test running with filename as None
+        nt.assert_raises(AssertionError, xrfi.xrfi_run, None, args, history)
+
         # test running with too many files
         cmd = ' '.join([arguments, 'file1', 'file2'])
         args = a.parse_args(cmd.split())
@@ -420,6 +423,28 @@ class TestXrfiRun(object):
         cmd = ' '.join([arguments, xx_file])
         args = a.parse_args(cmd.split())
         xrfi.xrfi_run(args.filename, args, cmd)
+        for f in dest_files:
+            nt.assert_true(os.path.exists(f))
+            os.remove(f)
+
+        # test running without a filename
+        dest_files = []
+        dest_files.append(os.path.join(DATA_PATH, 'test_output',
+                                       'zen.2457698.40355.xx.HH.uvc.vis.uvfits.flags.npz'))
+        dest_files.append(os.path.join(DATA_PATH, 'test_output',
+                                       'zen.2457698.40355.xx.HH.uvcAA.omni.calfits.g.flags.npz'))
+        dest_files.append(os.path.join(DATA_PATH, 'test_output',
+                                       'zen.2457698.40355.xx.HH.uvcAA.omni.calfits.x.flags.npz'))
+        for f in dest_files:
+            if os.path.exists(f):
+                os.remove(f)
+        cmd = ' '.join([arguments, ''])
+        args = a.parse_args(cmd.split())
+        nt.assert_true
+        # Note we need to implement this checkWarnings, but right now there are
+        # calfits warnings that are machine specific. TODO.
+        # uvtest.checkWarnings(xrfi.xrfi_run, [None, args, cmd], nwarnings=1, message='indata is none,')
+        xrfi.xrfi_run(None, args, cmd)
         for f in dest_files:
             nt.assert_true(os.path.exists(f))
             os.remove(f)

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -5,17 +5,20 @@ import warnings
 import argparse
 import numpy as np
 
+
 # argument-generating function for *_run wrapper functions
 def get_metrics_ArgumentParser(method_name):
     """
     Function to get an ArgumentParser instance for working with metrics wrappers.
 
     Args:
-        method_name -- target wrapper, must be "ant_metrics", "firstcal_metrics", "omnical_metrics", or "xrfi"
+        method_name -- target wrapper, must be "ant_metrics", "firstcal_metrics",
+                       "omnical_metrics", "xrfi_run", "delay_xrfi_run", or "xrfi_apply"
     Returns:
         a -- an argparse.ArgumentParser instance with the relevant options for the selected method
     """
-    methods = ["ant_metrics", "firstcal_metrics", "omnical_metrics", "xrfi_run", "xrfi_apply"]
+    methods = ["ant_metrics", "firstcal_metrics", "omnical_metrics", "xrfi_run",
+               "delay_xrfi_run", "xrfi_apply"]
     if method_name not in methods:
         raise AssertionError('method_name must be one of {}'.format(','.join(methods)))
 
@@ -132,6 +135,75 @@ def get_metrics_ArgumentParser(method_name):
                        'visibilities formed with these antennas will be set to True.')
         a.add_argument('filename', metavar='filename', nargs='*', type=str, default=[],
                        help='file for which to flag RFI (only one file allowed).')
+    elif method_name == 'delay_xrfi_run':
+        a.prog = 'delay_xrfi_run.py'
+        a.add_argument('--infile_format', default='miriad', type=str,
+                       help='File format for input files. Default is miriad.')
+        a.add_argument('--extension', default='.flags.npz', type=str,
+                       help='Extension to be appended to input file name. Default is ".flags.npz".')
+        a.add_argument('--summary', action='store_true', default=False,
+                       help='Run summary of RFI flags and store in npz file.')
+        a.add_argument('--summary_ext', default='.flag_summary.npz',
+                       type=str, help='Extension to be appended to input file name'
+                       ' for summary file. Default is ".flag_summary.npz"')
+        a.add_argument('--xrfi_path', default='', type=str,
+                       help='Path to save flag files to. Default is same directory as input file.')
+        a.add_argument('--algorithm', default='xrfi_simple', type=str,
+                       help='RFI-flagging algorithm to use. Default is xrfi_simple.')
+        a.add_argument('--model_file', default=None, type=str, help='Model visibility '
+                       'file to flag on.')
+        a.add_argument('--model_file_format', default='uvfits', type=str,
+                       help='File format for input files. Default is uvfits.')
+        a.add_argument('--calfits_file', default=None, type=str, help='Calfits file '
+                       'to use to flag on gains and/or chisquared values.')
+        a.add_argument('--nsig_df', default=6.0, type=float, help='Number of sigma '
+                       'above median value to flag in f direction for xrfi_simple. Default is 6.')
+        a.add_argument('--nsig_dt', default=6.0, type=float,
+                       help='Number of sigma above median value to flag in t direction'
+                       ' for xrfi_simple. Default is 6.')
+        a.add_argument('--nsig_all', default=0.0, type=float,
+                       help='Number of overall sigma above median value to flag'
+                       ' for xrfi_simple. Default is 0 (skip).')
+        a.add_argument('--kt_size', default=8, type=int,
+                       help='Size of kernel in time dimension for detrend in xrfi '
+                       'algorithm. Default is 8.')
+        a.add_argument('--kf_size', default=8, type=int,
+                       help='Size of kernel in frequency dimension for detrend in '
+                       'xrfi algorithm. Default is 8.')
+        a.add_argument('--sig_init', default=6.0, type=float,
+                       help='Starting number of sigmas to flag on. Default is 6.')
+        a.add_argument('--sig_adj', default=2.0, type=float,
+                       help='Number of sigmas to flag on for data adjacent to a flag. Default is 2.')
+        a.add_argument('--px_threshold', default=0.2, type=float,
+                       help='Fraction of flags required to trigger a broadcast across'
+                       ' baselines for a given (time, frequency) pixel. Default is 0.2.')
+        a.add_argument('--freq_threshold', default=0.5, type=float,
+                       help='Fraction of channels required to trigger broadcast across'
+                       ' frequency (single time). Default is 0.5.')
+        a.add_argument('--time_threshold', default=0.05, type=float,
+                       help='Fraction of times required to trigger broadcast across'
+                       ' time (single frequency). Default is 0.05.')
+        a.add_argument('--ex_ants', default='', type=str,
+                       help='Comma-separated list of antennas to exclude. Flags of visibilities '
+                       'formed with these antennas will be set to True.')
+        a.add_argument('--metrics_json', default='', type=str,
+                       help='Metrics file that contains a list of excluded antennas. Flags of '
+                       'visibilities formed with these antennas will be set to True.')
+        a.add_argument('filename', metavar='filename', nargs='?', type=str, default=None,
+                       help='file for which to flag RFI (only one file allowed).')
+        # Delay filter options
+        a.add_argument("--standoff", type=float, default=15.0, help='fixed additional delay beyond the horizon (default 15 ns)')
+        a.add_argument("--horizon", type=float, default=1.0, help='proportionality constant for bl_len where 1.0 (default) is the horizon\
+                                  (full light travel time)')
+        a.add_argument("--tol", type=float, default=1e-5, help='CLEAN algorithm convergence tolerance (default 1e-5). '
+                       'NOTE: default is different from default when running delay_filter_run.py.')
+        a.add_argument("--window", type=str, default="none", help='window function for frequency filtering (default "none",\
+                                  see aipy.dsp.gen_window for options')
+        a.add_argument("--skip_wgt", type=float, default=0.1, help='skips filtering rows with unflagged fraction ~< skip_wgt (default 0.1)')
+        a.add_argument("--maxiter", type=int, default=100, help='maximum iterations for aipy.deconv.clean to converge (default 100)')
+        a.add_argument('--waterfalls', default=None, type=str, help='comma separated '
+                       'list of npz files containing waterfalls of flags to broadcast '
+                       'to full flag array and apply before delay filter.')
     elif method_name == 'xrfi_apply':
         a.prog = 'xrfi_apply.py'
         a.add_argument('--infile_format', default='miriad', type=str,

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -137,71 +137,74 @@ def get_metrics_ArgumentParser(method_name):
                        help='file for which to flag RFI (only one file allowed).')
     elif method_name == 'delay_xrfi_run':
         a.prog = 'delay_xrfi_run.py'
-        a.add_argument('--infile_format', default='miriad', type=str,
-                       help='File format for input files. Default is miriad.')
-        a.add_argument('--extension', default='.flags.npz', type=str,
-                       help='Extension to be appended to input file name. Default is ".flags.npz".')
-        a.add_argument('--summary', action='store_true', default=False,
-                       help='Run summary of RFI flags and store in npz file.')
-        a.add_argument('--summary_ext', default='.flag_summary.npz',
-                       type=str, help='Extension to be appended to input file name'
-                       ' for summary file. Default is ".flag_summary.npz"')
-        a.add_argument('--xrfi_path', default='', type=str,
-                       help='Path to save flag files to. Default is same directory as input file.')
-        a.add_argument('--algorithm', default='xrfi_simple', type=str,
-                       help='RFI-flagging algorithm to use. Default is xrfi_simple.')
-        a.add_argument('--model_file', default=None, type=str, help='Model visibility '
-                       'file to flag on.')
-        a.add_argument('--model_file_format', default='uvfits', type=str,
-                       help='File format for input files. Default is uvfits.')
-        a.add_argument('--calfits_file', default=None, type=str, help='Calfits file '
-                       'to use to flag on gains and/or chisquared values.')
-        a.add_argument('--nsig_df', default=6.0, type=float, help='Number of sigma '
-                       'above median value to flag in f direction for xrfi_simple. Default is 6.')
-        a.add_argument('--nsig_dt', default=6.0, type=float,
-                       help='Number of sigma above median value to flag in t direction'
-                       ' for xrfi_simple. Default is 6.')
-        a.add_argument('--nsig_all', default=0.0, type=float,
-                       help='Number of overall sigma above median value to flag'
-                       ' for xrfi_simple. Default is 0 (skip).')
-        a.add_argument('--kt_size', default=8, type=int,
-                       help='Size of kernel in time dimension for detrend in xrfi '
-                       'algorithm. Default is 8.')
-        a.add_argument('--kf_size', default=8, type=int,
-                       help='Size of kernel in frequency dimension for detrend in '
-                       'xrfi algorithm. Default is 8.')
-        a.add_argument('--sig_init', default=6.0, type=float,
-                       help='Starting number of sigmas to flag on. Default is 6.')
-        a.add_argument('--sig_adj', default=2.0, type=float,
-                       help='Number of sigmas to flag on for data adjacent to a flag. Default is 2.')
-        a.add_argument('--px_threshold', default=0.2, type=float,
-                       help='Fraction of flags required to trigger a broadcast across'
-                       ' baselines for a given (time, frequency) pixel. Default is 0.2.')
-        a.add_argument('--freq_threshold', default=0.5, type=float,
-                       help='Fraction of channels required to trigger broadcast across'
-                       ' frequency (single time). Default is 0.5.')
-        a.add_argument('--time_threshold', default=0.05, type=float,
-                       help='Fraction of times required to trigger broadcast across'
-                       ' time (single frequency). Default is 0.05.')
-        a.add_argument('--ex_ants', default='', type=str,
-                       help='Comma-separated list of antennas to exclude. Flags of visibilities '
-                       'formed with these antennas will be set to True.')
-        a.add_argument('--metrics_json', default='', type=str,
-                       help='Metrics file that contains a list of excluded antennas. Flags of '
-                       'visibilities formed with these antennas will be set to True.')
         a.add_argument('filename', metavar='filename', nargs='?', type=str, default=None,
                        help='file for which to flag RFI (only one file allowed).')
-        # Delay filter options
-        a.add_argument("--standoff", type=float, default=15.0, help='fixed additional delay beyond the horizon (default 15 ns)')
-        a.add_argument("--horizon", type=float, default=1.0, help='proportionality constant for bl_len where 1.0 (default) is the horizon\
+        x = a.add_argument_group(title='XRFI options', description='Options related to '
+                                 'the RFI flagging routine.')
+        x.add_argument('--infile_format', default='miriad', type=str,
+                       help='File format for input files. Default is miriad.')
+        x.add_argument('--extension', default='.flags.npz', type=str,
+                       help='Extension to be appended to input file name. Default is ".flags.npz".')
+        x.add_argument('--summary', action='store_true', default=False,
+                       help='Run summary of RFI flags and store in npz file.')
+        x.add_argument('--summary_ext', default='.flag_summary.npz',
+                       type=str, help='Extension to be appended to input file name'
+                       ' for summary file. Default is ".flag_summary.npz"')
+        x.add_argument('--xrfi_path', default='', type=str,
+                       help='Path to save flag files to. Default is same directory as input file.')
+        x.add_argument('--algorithm', default='xrfi_simple', type=str,
+                       help='RFI-flagging algorithm to use. Default is xrfi_simple.')
+        x.add_argument('--model_file', default=None, type=str, help='Model visibility '
+                       'file to flag on.')
+        x.add_argument('--model_file_format', default='uvfits', type=str,
+                       help='File format for input files. Default is uvfits.')
+        x.add_argument('--calfits_file', default=None, type=str, help='Calfits file '
+                       'to use to flag on gains and/or chisquared values.')
+        x.add_argument('--nsig_df', default=6.0, type=float, help='Number of sigma '
+                       'above median value to flag in f direction for xrfi_simple. Default is 6.')
+        x.add_argument('--nsig_dt', default=6.0, type=float,
+                       help='Number of sigma above median value to flag in t direction'
+                       ' for xrfi_simple. Default is 6.')
+        x.add_argument('--nsig_all', default=0.0, type=float,
+                       help='Number of overall sigma above median value to flag'
+                       ' for xrfi_simple. Default is 0 (skip).')
+        x.add_argument('--kt_size', default=8, type=int,
+                       help='Size of kernel in time dimension for detrend in xrfi '
+                       'algorithm. Default is 8.')
+        x.add_argument('--kf_size', default=8, type=int,
+                       help='Size of kernel in frequency dimension for detrend in '
+                       'xrfi algorithm. Default is 8.')
+        x.add_argument('--sig_init', default=6.0, type=float,
+                       help='Starting number of sigmas to flag on. Default is 6.')
+        x.add_argument('--sig_adj', default=2.0, type=float,
+                       help='Number of sigmas to flag on for data adjacent to a flag. Default is 2.')
+        x.add_argument('--px_threshold', default=0.2, type=float,
+                       help='Fraction of flags required to trigger a broadcast across'
+                       ' baselines for a given (time, frequency) pixel. Default is 0.2.')
+        x.add_argument('--freq_threshold', default=0.5, type=float,
+                       help='Fraction of channels required to trigger broadcast across'
+                       ' frequency (single time). Default is 0.5.')
+        x.add_argument('--time_threshold', default=0.05, type=float,
+                       help='Fraction of times required to trigger broadcast across'
+                       ' time (single frequency). Default is 0.05.')
+        x.add_argument('--ex_ants', default='', type=str,
+                       help='Comma-separated list of antennas to exclude. Flags of visibilities '
+                       'formed with these antennas will be set to True.')
+        x.add_argument('--metrics_json', default='', type=str,
+                       help='Metrics file that contains a list of excluded antennas. Flags of '
+                       'visibilities formed with these antennas will be set to True.')
+        d = a.add_argument_group(title='Delay filter options', description='Options '
+                                 'related to the delay filter which is applied before flagging.')
+        d.add_argument("--standoff", type=float, default=15.0, help='fixed additional delay beyond the horizon (default 15 ns)')
+        d.add_argument("--horizon", type=float, default=1.0, help='proportionality constant for bl_len where 1.0 (default) is the horizon\
                                   (full light travel time)')
-        a.add_argument("--tol", type=float, default=1e-5, help='CLEAN algorithm convergence tolerance (default 1e-5). '
+        d.add_argument("--tol", type=float, default=1e-5, help='CLEAN algorithm convergence tolerance (default 1e-5). '
                        'NOTE: default is different from default when running delay_filter_run.py.')
-        a.add_argument("--window", type=str, default="none", help='window function for frequency filtering (default "none",\
+        d.add_argument("--window", type=str, default="none", help='window function for frequency filtering (default "none",\
                                   see aipy.dsp.gen_window for options')
-        a.add_argument("--skip_wgt", type=float, default=0.1, help='skips filtering rows with unflagged fraction ~< skip_wgt (default 0.1)')
-        a.add_argument("--maxiter", type=int, default=100, help='maximum iterations for aipy.deconv.clean to converge (default 100)')
-        a.add_argument('--waterfalls', default=None, type=str, help='comma separated '
+        d.add_argument("--skip_wgt", type=float, default=0.1, help='skips filtering rows with unflagged fraction ~< skip_wgt (default 0.1)')
+        d.add_argument("--maxiter", type=int, default=100, help='maximum iterations for aipy.deconv.clean to converge (default 100)')
+        d.add_argument('--waterfalls', default=None, type=str, help='comma separated '
                        'list of npz files containing waterfalls of flags to broadcast '
                        'to full flag array and apply before delay filter.')
     elif method_name == 'xrfi_apply':

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -267,7 +267,7 @@ def xrfi_run(indata, args, history):
     observations. Each set of flagging will be stored, as well as compressed versions.
     """
     if indata is None:
-        if (args.model_file is None) and (args.calfits_fils is None):
+        if (args.model_file is None) and (args.calfits_file is None):
             raise AssertionError('Must provide at least one of: filename, '
                                  'model_file, or calfits_file.')
         warnings.warn('indata is none, not flagging on any data visibilities.')
@@ -329,10 +329,11 @@ def xrfi_run(indata, args, history):
             uvm.read_fhd(args.model_file)
         else:
             raise ValueError('Unrecognized input file format ' + str(args.model_file_format))
-        if not (np.allclose(np.unique(uvd.time_array), np.unique(uvm.time_array), atol=1e-5, rtol=0) and
-                np.allclose(uvd.freq_array, uvm.freq_array, atol=1., rtol=0)):
-            raise ValueError('Time and frequency axes of model vis file must match'
-                             'the data file.')
+        if indata is not None:
+            if not (np.allclose(np.unique(uvd.time_array), np.unique(uvm.time_array), atol=1e-5, rtol=0) and
+                    np.allclose(uvd.freq_array, uvm.freq_array, atol=1., rtol=0)):
+                raise ValueError('Time and frequency axes of model vis file must match'
+                                 'the data file.')
         m_flag_array = vis_flag(uvm, args)
         m_waterfall = flags2waterfall(uvm, flag_array=m_flag_array)
         m_wf_t = threshold_flags(m_waterfall, px_threshold=args.px_threshold,
@@ -343,10 +344,11 @@ def xrfi_run(indata, args, history):
     if args.calfits_file is not None:
         uvc = UVCal()
         uvc.read_calfits(args.calfits_file)
-        if not (np.allclose(np.unique(uvd.time_array), np.unique(uvc.time_array), atol=1e-5, rtol=0) and
-                np.allclose(uvd.freq_array, uvc.freq_array, atol=1., rtol=0)):
-            raise ValueError('Time and frequency axes of calfits file must match'
-                             'the data file.')
+        if indata is not None:
+            if not (np.allclose(np.unique(uvd.time_array), np.unique(uvc.time_array), atol=1e-5, rtol=0) and
+                    np.allclose(uvd.freq_array, uvc.freq_array, atol=1., rtol=0)):
+                raise ValueError('Time and frequency axes of calfits file must match'
+                                 'the data file.')
         g_flag_array, x_flag_array = cal_flag(uvc, args)
         g_waterfall = flags2waterfall(uvc, flag_array=g_flag_array)
         x_waterfall = flags2waterfall(uvc, flag_array=x_flag_array)

--- a/scripts/delay_xrfi_run.py
+++ b/scripts/delay_xrfi_run.py
@@ -7,21 +7,30 @@ from hera_cal import delay_filter
 from hera_cal import io
 from pyuvdata import UVData
 
-ax = qm_utils.get_metrics_ArgumentParser('xrfi_run')
-ad = delay_filter.delay_filter_argparser()
-args_x = ax.parse_known_args()[0]
-args_d = ad.parse_known_args()[0]
-filename = args_x.filename
+a = qm_utils.get_metrics_ArgumentParser('delay_xrfi_run')
+args = a.parse_args()
+filename = args.filename
 history = ' '.join(sys.argv)
 
 # Read data, apply delay filter, update UVData object
-dfil = delay_filter.Delay_Filter()
 uv = UVData()
 uv.read_miriad(filename)
+# apply a priori waterfall flags
+waterfalls == []
+if args.waterfalls is not None:
+    for wfile in args.waterfalls.split(','):
+        d = np.load(wfile)
+        waterfalls.append(d['waterfall'])
+    if len(waterfalls) > 0:
+        wf_full = sum(waterfalls).astype(bool)
+        uv.flag_array += xrfi.waterfall2flags(wf_full, uv)
+
+# Stuff into delay filter object, run delay filter
+dfil = delay_filter.Delay_Filter()
 dfil.load_data(uv)
-dfil.run_filter(standoff=args_d.standoff, horizon=args_d.horizon, tol=args_d.tol,
-                window=args_d.window, skip_wgt=args_d.skip_wgt, maxiter=args_d.maxiter)
+dfil.run_filter(standoff=args.standoff, horizon=args.horizon, tol=args.tol,
+                window=args.window, skip_wgt=args.skip_wgt, maxiter=args.maxiter)
 io.update_uvdata(dfil.input_data, data=dfil.filtered_residuals)
 
 # Run xrfi
-xrfi.xrfi_run(dfil.input_data, args_x, history)
+xrfi.xrfi_run(dfil.input_data, args, history)


### PR DESCRIPTION
This PR goes hand in hand with one on hera_opm. The goal is to run xrfi on calfits and model vis files before running the delay filter + xrfi on data.
Biggest changes here are updating the top level script to do what is described above, allowing xrfi_run to not take an input file, and a new argument parser to handle this.