### PR TITLE
Let delay_filter update flags due to skip_wgt

### DIFF
--- a/scripts/delay_xrfi_run.py
+++ b/scripts/delay_xrfi_run.py
@@ -31,7 +31,7 @@ dfil = delay_filter.Delay_Filter()
 dfil.load_data(uv)
 dfil.run_filter(standoff=args.standoff, horizon=args.horizon, tol=args.tol,
                 window=args.window, skip_wgt=args.skip_wgt, maxiter=args.maxiter)
-io.update_uvdata(dfil.input_data, data=dfil.filtered_residuals)
+io.update_uvdata(dfil.input_data, data=dfil.filtered_residuals, flags=dfil.flags)
 
 # Run xrfi
 xrfi.xrfi_run(dfil.input_data, args, history)


### PR DESCRIPTION
This change reflects the changes in https://github.com/HERA-Team/hera_cal/pull/240 which themselves stem from https://github.com/HERA-Team/uvtools/pull/19

Basically, if most of the channels for a given time are flagged, delay CLEAN is skipped. This update also keeps a record of what was skipped so that the dfil.flags gets updated when the filter is run and skip_wgt gets triggered.