### PR TITLE
added baseline_array to xrfi npz output

### DIFF
--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -344,6 +344,11 @@ class TestXrfiRun(object):
         history = cmd
         xrfi.xrfi_run(args.filename, args, cmd)
         nt.assert_true(os.path.exists(dest_file))
+        # load data and test all arrays exist in file
+        d = np.load(dest_file)
+        nt.assert_true(np.array(map(lambda n: n in d, ['baseline_array', 'waterfall', 'flag_array', 'history'])).all())
+        # test baseline array has same shape as flag_array axis 0
+        nt.assert_equal(len(d['baseline_array']), d['flag_array'].shape[0])
         os.remove(dest_file)
 
         # test running with UVData object

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -386,7 +386,8 @@ def xrfi_run(indata, args, history):
         basename = os.path.basename(filename)
         outfile = ''.join([basename, args.extension])
         outpath = os.path.join(dirname, outfile)
-        np.savez(outpath, flag_array=d_flag_array, waterfall=d_wf_t, history=history)
+        np.savez(outpath, flag_array=d_flag_array, waterfall=d_wf_t, baseline_array=uvd.baseline_array, 
+                 history=history)
         if (args.summary):
             sum_file = ''.join([basename, args.summary_ext])
             sum_path = os.path.join(dirname, sum_file)
@@ -397,7 +398,8 @@ def xrfi_run(indata, args, history):
             dirname = os.path.dirname(os.path.abspath(args.model_file))
         outfile = ''.join([os.path.basename(args.model_file), args.extension])
         outpath = os.path.join(dirname, outfile)
-        np.savez(outpath, flag_array=m_flag_array, waterfall=m_wf_t, history=history)
+        np.savez(outpath, flag_array=m_flag_array, waterfall=m_wf_t, baseline_array=uvm.baseline_array, 
+                 history=history)
     if args.calfits_file is not None:
         # Save flags from gains and chisquareds in separate files
         if args.xrfi_path == '':


### PR DESCRIPTION
This will help us to tie RFI flags across files without having to load in the visibility data itself. If we can index RFI flags based on their baseline, we can begin to broadcast flags across an entire night (similar to a `time_threshold` but for the whole night)