### PR TITLE
Integration time fix

### DIFF
--- a/hera_qm/tests/test_vis_metrics.py
+++ b/hera_qm/tests/test_vis_metrics.py
@@ -41,10 +41,18 @@ class TestMethods(unittest.TestCase):
     def test_check_noise_variance(self):
         nos = vis_metrics.check_noise_variance(self.data)
         for bl in self.data.get_antpairs():
+            inds = self.data.antpair2ind(*bl)
             n = nos[bl + ('XX',)]
             self.assertEqual(n.shape, (self.data.Nfreqs - 1,))
-            nsamp = self.data.channel_width * self.data.integration_time
-            np.testing.assert_almost_equal(n, np.ones_like(n) * nsamp, -np.log10(nsamp))
+            nsamp = self.data.channel_width * self.data.integration_time[inds][0]
+            np.testing.assert_almost_equal(n, np.ones_like(n) * nsamp,
+                                           -np.log10(nsamp))
+
+    def test_check_noise_variance_inttime_error(self):
+        self.data.integration_time = (self.data.integration_time
+                                      * np.arange(self.data.integration_time.size))
+        self.assertRaises(NotImplementedError,
+                          vis_metrics.check_noise_variance, self.data)
 
 
 if __name__ == '__main__':

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -267,6 +267,7 @@ class TestLines(Template, unittest.TestCase):
 class TestBackground(Template, unittest.TestCase):
 
     def setUp(self):
+        np.random.seed(0)
         RFI = 50
         NTRIALS = 10
         NSIG = 10

--- a/hera_qm/vis_metrics.py
+++ b/hera_qm/vis_metrics.py
@@ -24,7 +24,6 @@ def check_noise_variance(data):
         inds = data.antpair2ind(key[0], key[1])
         integration_time = data.integration_time[inds]
         if not len(set(integration_time)) == 1:
-            # what do if not same?
             raise NotImplementedError(("Integration times which vary with "
                                        "time are currently not supported."))
         else:

--- a/hera_qm/vis_metrics.py
+++ b/hera_qm/vis_metrics.py
@@ -6,15 +6,19 @@ import numpy as np
 
 
 def check_noise_variance(data):
-    '''Function to calculate the noise levels of each baseline/pol combination,
-    relative to the noise on the autos.
+    """Calculate the noise levels of each baseline/pol relative to the autos.
+
+    Calculates the noise for each baseline/pol by differencing along frequency
+    dimension and compares to the noise on the auto-spectra for each
+    antenna in the baseline.
 
     Args:
         data (UVData): UVData object with data.
 
     Returns:
-        Cij (dict): dictionary of variance measurements with keywords of (ant1, ant2, pol)
-    '''
+        Cij (dict): dictionary of variance measurements
+                    has keywords of (ant1, ant2, pol)
+    """
     Cij = {}
     for key, d in data.antpairpol_iter():
         w = data.get_nsamples(key)
@@ -22,10 +26,13 @@ def check_noise_variance(data):
         ai = data.get_data((key[0], key[0], key[2])).real
         aj = data.get_data((key[1], key[1], key[2])).real
         ww = w[1:, 1:] * w[1:, :-1] * w[:-1, 1:] * w[:-1, :-1]
-        dd = ((d[:-1, :-1] - d[:-1, 1:]) - (d[1:, :-1] - d[1:, 1:])) * ww / np.sqrt(4)
-        dai = ((ai[:-1, :-1] + ai[:-1, 1:]) + (ai[1:, :-1] + ai[1:, 1:])) * ww / 4
-        daj = ((aj[:-1, :-1] + aj[:-1, 1:]) + (aj[1:, :-1] + aj[1:, 1:])) * ww / 4
         Cij[key] = (np.sum(np.abs(dd)**2, axis=0) / np.sum(dai * daj, axis=0) *
                     (data.channel_width * data.integration_time))
+        dd = (((d[:-1, :-1] - d[:-1, 1:]) - (d[1:, :-1] - d[1:, 1:])) * ww
+              / np.sqrt(4))
+        dai = (((ai[:-1, :-1] + ai[:-1, 1:]) + (ai[1:, :-1] + ai[1:, 1:])) * ww
+               / 4)
+        daj = (((aj[:-1, :-1] + aj[:-1, 1:]) + (aj[1:, :-1] + aj[1:, 1:])) * ww
+               / 4)
 
     return Cij

--- a/hera_qm/vis_metrics.py
+++ b/hera_qm/vis_metrics.py
@@ -26,13 +26,12 @@ def check_noise_variance(data):
         ai = data.get_data((key[0], key[0], key[2])).real
         aj = data.get_data((key[1], key[1], key[2])).real
         ww = w[1:, 1:] * w[1:, :-1] * w[:-1, 1:] * w[:-1, :-1]
-        Cij[key] = (np.sum(np.abs(dd)**2, axis=0) / np.sum(dai * daj, axis=0) *
-                    (data.channel_width * data.integration_time))
         dd = (((d[:-1, :-1] - d[:-1, 1:]) - (d[1:, :-1] - d[1:, 1:])) * ww
               / np.sqrt(4))
         dai = (((ai[:-1, :-1] + ai[:-1, 1:]) + (ai[1:, :-1] + ai[1:, 1:])) * ww
                / 4)
         daj = (((aj[:-1, :-1] + aj[:-1, 1:]) + (aj[1:, :-1] + aj[1:, 1:])) * ww
                / 4)
-
+        Cij[key] = (np.sum(np.abs(dd)**2, axis=0) / np.sum(dai * daj, axis=0) *
+                    (data.channel_width * data.integration_time))
     return Cij

--- a/hera_qm/vis_metrics.py
+++ b/hera_qm/vis_metrics.py
@@ -21,6 +21,14 @@ def check_noise_variance(data):
     """
     Cij = {}
     for key, d in data.antpairpol_iter():
+        inds = data.antpair2ind(key[0], key[1])
+        integration_time = data.integration_time[inds]
+        if not len(set(integration_time)) == 1:
+            # what do if not same?
+            raise NotImplementedError(("Integration times which vary with "
+                                       "time are currently not supported."))
+        else:
+            integration_time = integration_time[0]
         w = data.get_nsamples(key)
         bl = (key[0], key[1])
         ai = data.get_data((key[0], key[0], key[2])).real
@@ -32,6 +40,7 @@ def check_noise_variance(data):
                / 4)
         daj = (((aj[:-1, :-1] + aj[:-1, 1:]) + (aj[1:, :-1] + aj[1:, 1:])) * ww
                / 4)
-        Cij[key] = (np.sum(np.abs(dd)**2, axis=0) / np.sum(dai * daj, axis=0) *
-                    (data.channel_width * data.integration_time))
+        Cij[key] = (np.sum(np.abs(dd)**2, axis=0) / np.sum(dai * daj, axis=0)
+                    * (data.channel_width * integration_time))
+
     return Cij


### PR DESCRIPTION
This will still fail travis until the pyuvdata issue with integration_time cast as float32 is addressed. 

Fixed an issue where np.random.seed was not set in a test_xrfi function and test failed.

checks if integration_time is the same for all times in vis_count. if true just grab the first time, currently
raise NotImplementedError if the integration time varies with time.

On 3rd thought the line that checks this looks like len(set(integration_time[inds])), this could still fail if there are floating point errors, perhaps it should get changed to something like an all close