### PR TITLE
Circumvent nosetets logging dumps on test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3
 
-script: nosetests hera_qm --with-coverage --cover-package=hera_qm
+script: nosetests hera_qm --nologcapture --with-coverage --cover-package=hera_qm
 
 after_success:
   - coveralls

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -8,4 +8,4 @@ cd $DIR/..
 python setup.py install
 
 cd hera_qm/tests
-nosetests --with-coverage --cover-erase --cover-package=hera_qm --cover-html "$@"
+nosetests --nologcapture --with-coverage --cover-erase --cover-package=hera_qm --cover-html "$@"


### PR DESCRIPTION
added a --nologcapture flag on all nosetests calls in .travis.yml and test_coverage script. This suppresses the large logging dump when an exception is raised during testing.  Not sure if there is better way to get these logs not to show up. Sometimes it feels like it depends on how conda is feeling that day.