### PR TITLE
Uvh5 xrfi

### DIFF
--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -646,11 +646,6 @@ class TestWrappers():
         nt.assert_raises(ValueError, xrfi.xrfi_h1c_run, uvd,
                          'Just a test.', filename=5)
 
-    def test_xrfi_h1c_run_ms_file(self):
-        # test incorrectly inputting an ms file
-        nt.assert_raises(ValueError, xrfi.xrfi_h1c_run, test_d_file,
-                         infile_format='ms', history='Just a test.')
-
     def test_xrfi_h1c_run_uvfits_no_xrfi_path(self):
         # test uvfits file and no xrfi path
         uvd = UVData()
@@ -726,15 +721,6 @@ class TestWrappers():
                          filename=test_d_file, model_file=bad_uvfits_test,
                          model_file_format='uvfits', xrfi_path=xrfi_path, kt_size=3)
 
-    def test_xrfi_h1c_run_unrecognized_model(self):
-        # check for unrecognized model file type
-        uvd = UVData()
-        uvd.read_miriad(test_d_file)
-        nt.assert_raises(ValueError, xrfi.xrfi_h1c_run, uvd, 'Just a test.',
-                         filename=test_d_file, extension='flag', summary=True,
-                         model_file=test_uvfits_file, model_file_format='ms', xrfi_path=xrfi_path,
-                         kt_size=3)
-
     def test_xrfi_h1c_run_input_calfits(self):
         # input calfits
         uvd = UVData()
@@ -791,6 +777,15 @@ class TestWrappers():
         nt.assert_true(os.path.exists(dest_file))
         os.remove(dest_file)
 
+        # uvh5 output
+        dest_file = os.path.join(xrfi_path, os.path.basename(test_d_file) + 'R.uvh5')
+        if os.path.exists(dest_file):
+            os.remove(dest_file)
+        xrfi.xrfi_h1c_apply(test_d_file, history, xrfi_path=xrfi_path, flag_file=test_f_file_flags,
+                            outfile_format='uvh5', extension='R.uvh5', output_uvflag=False)
+        nt.assert_true(os.path.exists(dest_file))
+        os.remove(dest_file)
+
     def test_xrfi_h1c_apply_errors(self):
         xrfi_path = os.path.join(DATA_PATH, 'test_output')
         wf_file1 = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA.omni.calfits.g.flags.h5')
@@ -801,11 +796,6 @@ class TestWrappers():
 
         # test running with two files
         nt.assert_raises(AssertionError, xrfi.xrfi_h1c_apply, ['file1', 'file2'], history)
-
-        # Conflicting file formats
-        nt.assert_raises(IOError, xrfi.xrfi_h1c_apply, test_d_file, history, infile_format='uvfits')
-        nt.assert_raises(Exception, xrfi.xrfi_h1c_apply, test_d_file, history, infile_format='fhd')
-        nt.assert_raises(ValueError, xrfi.xrfi_h1c_apply, test_d_file, history, infile_format='bla')
 
         # Outfile error
         nt.assert_raises(ValueError, xrfi.xrfi_h1c_apply, test_d_file, history, outfile_format='bla')

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -748,6 +748,10 @@ class TestWrappers():
                          filename=test_d_file, calfits_file=bad_calfits,
                          xrfi_path=xrfi_path, kt_size=3)
 
+    def test_xrfi_h1c_run_indata_string_filename_not_string(self):
+        nt.assert_raises(ValueError, xrfi.xrfi_h1c_run, 'foo', 'Just a test.',
+                         filename=3)
+
     def test_xrfi_h1c_apply(self):
         xrfi_path = os.path.join(DATA_PATH, 'test_output')
         wf_file1 = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA.omni.calfits.g.flags.h5')

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -138,7 +138,7 @@ def get_metrics_ArgumentParser(method_name):
     elif method_name == 'xrfi_run':
         a.prog = 'xrfi_run.py'
         a.add_argument('--infile_format', default='miriad', type=str,
-                       help='File format for input files. Default is miriad.')
+                       help='File format for input files. DEPRECATED, but kept for legacy.')
         a.add_argument('--extension', default='.flags.npz', type=str,
                        help='Extension to be appended to input file name. Default is ".flags.npz".')
         a.add_argument('--summary', action='store_true', default=False,
@@ -153,7 +153,7 @@ def get_metrics_ArgumentParser(method_name):
         a.add_argument('--model_file', default=None, type=str, help='Model visibility '
                        'file to flag on.')
         a.add_argument('--model_file_format', default='uvfits', type=str,
-                       help='File format for input files. Default is uvfits.')
+                       help='File format for input files. DEPRECATED, but kept for legacy.')
         a.add_argument('--calfits_file', default=None, type=str, help='Calfits file '
                        'to use to flag on gains and/or chisquared values.')
         a.add_argument('--nsig_df', default=6.0, type=float, help='Number of sigma '
@@ -198,7 +198,7 @@ def get_metrics_ArgumentParser(method_name):
         x = a.add_argument_group(title='XRFI options', description='Options related to '
                                  'the RFI flagging routine.')
         x.add_argument('--infile_format', default='miriad', type=str,
-                       help='File format for input files. Default is miriad.')
+                       help='File format for input files. DEPRECATED, but kept for legacy.')
         x.add_argument('--extension', default='.flags.npz', type=str,
                        help='Extension to be appended to input file name. Default is ".flags.npz".')
         x.add_argument('--summary', action='store_true', default=False,
@@ -213,7 +213,7 @@ def get_metrics_ArgumentParser(method_name):
         x.add_argument('--model_file', default=None, type=str, help='Model visibility '
                        'file to flag on.')
         x.add_argument('--model_file_format', default='uvfits', type=str,
-                       help='File format for input files. Default is uvfits.')
+                       help='File format for input files. DEPRECATED, but kept for legacy.')
         x.add_argument('--calfits_file', default=None, type=str, help='Calfits file '
                        'to use to flag on gains and/or chisquared values.')
         x.add_argument('--nsig_df', default=6.0, type=float, help='Number of sigma '
@@ -267,7 +267,7 @@ def get_metrics_ArgumentParser(method_name):
     elif method_name == 'xrfi_apply':
         a.prog = 'xrfi_apply.py'
         a.add_argument('--infile_format', default='miriad', type=str,
-                       help='File format for input files. Default is miriad.')
+                       help='File format for input files. DEPRECATED, but kept for legacy.')
         a.add_argument('--xrfi_path', default='', type=str,
                        help='Path to save output to. Default is same directory as input file.')
         a.add_argument('--outfile_format', default='miriad', type=str,

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -619,13 +619,13 @@ def xrfi_h1c_run(indata, history, infile_format='miriad', extension='.flags.h5',
     Args:
         indata -- Either UVData object or data file to run RFI flagging on.
         history -- history string to include in files
-        infile_format -- File format for input files. Default is miriad.
+        infile_format -- File format for input files. DEPRECATED, but kept for legacy.
         extension -- Extension to be appended to input file name. Default is ".flags.h5"
         summary -- Run summary of RFI flags and store in h5 file. Default is False.
         summary_ext -- Extension for summary file. Default is ".flag_summary.h5"
         xrfi_path -- Path to save flag files to. Default is same directory as input file.
         model_file -- Model visibility file to flag on.
-        model_file_format -- File format for input model file. Default is uvfits.
+        model_file_format -- File format for input model file. DEPRECATED, but kept for legacy.
         calfits_file -- Calfits file to use to flag on gains and/or chisquared values.
         kt_size -- Size of kernel in time dimension for detrend in xrfi algorithm. Default is 8.
         kf_size -- Size of kernel in frequency dimension for detrend in xrfi. Default is 8.
@@ -669,12 +669,7 @@ def xrfi_h1c_run(indata, history, infile_format='miriad', extension='.flags.h5',
         elif not isinstance(filename, str):
             raise ValueError('filename must be string path to file.')
         uvd = UVData()
-        if infile_format == 'miriad':
-            uvd.read_miriad(filename)
-        elif infile_format == 'uvfits':
-            uvd.read_uvfits(filename)
-        else:
-            raise ValueError('Unrecognized input file format ' + str(infile_format))
+        uvd.read(filename)
 
     # append to history
     history = 'Flagging command: "' + history + '", Using ' + hera_qm_version_str
@@ -714,12 +709,7 @@ def xrfi_h1c_run(indata, history, infile_format='miriad', extension='.flags.h5',
     # Flag on model visibilities
     if model_file is not None:
         uvm = UVData()
-        if model_file_format == 'miriad':
-            uvm.read_miriad(model_file)
-        elif model_file_format == 'uvfits':
-            uvm.read_uvfits(model_file)
-        else:
-            raise ValueError('Unrecognized input file format ' + str(model_file_format))
+        uvm.read(model_file)
         if indata is not None:
             if not (np.allclose(np.unique(uvd.time_array), np.unique(uvm.time_array),
                                 atol=1e-5, rtol=0)
@@ -782,7 +772,7 @@ def xrfi_h1c_apply(filename, history, infile_format='miriad', xrfi_path='',
     Args:
         filename -- Data file in which update flag array.
         history -- history string to include in files
-        infile_format -- File format for input files. Default is miriad.
+        infile_format -- File format for input files. DEPRECATED, but kept for legacy.
         xrfi_path -- Path to save output to. Default is same directory as input file.
         outfile_format -- File format for output files. Default is miriad.
         extension -- Extension to be appended to input file name. Default is "R".
@@ -804,14 +794,7 @@ def xrfi_h1c_apply(filename, history, infile_format='miriad', xrfi_path='',
     if isinstance(filename, (list, np.ndarray, tuple)):
         filename = filename[0]
     uvd = UVData()
-    if infile_format == 'miriad':
-        uvd.read_miriad(filename)
-    elif infile_format == 'uvfits':
-        uvd.read_uvfits(filename)
-    elif infile_format == 'fhd':
-        uvd.read_fhd(filename)
-    else:
-        raise ValueError('Unrecognized input file format ' + str(infile_format))
+    uvd.read(filename)
 
     full_list = []
     # Read in flag file

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -826,6 +826,8 @@ def xrfi_h1c_apply(filename, history, infile_format='miriad', xrfi_path='',
         if os.path.exists(outpath) and not overwrite:
             raise ValueError('File exists: skipping')
         uvd.write_uvfits(outpath, force_phase=True, spoof_nonessential=True)
+    elif outfile_format == 'uvh5':
+        uvd.write_uvh5(outpath, clobber=overwrite)
     else:
         raise ValueError('Unrecognized output file format ' + str(outfile_format))
     if output_uvflag:


### PR DESCRIPTION
Adds support for uvh5 files in xrfi. Actually, it removes the places where we specify the infile format and instead uses pyuvdata's generic read function. The one place where we write data, we can now use uvh5.
Fixes #209 