### PR TITLE
break out collapse_pol function in uvflag

### DIFF
--- a/hera_qm/tests/test_uvflag.py
+++ b/hera_qm/tests/test_uvflag.py
@@ -612,8 +612,6 @@ def test_collapse_pol():
     print(uvf2.polarization_array)
     uvf2.collapse_pol()
     nt.assert_true(len(uvf2.polarization_array) == 1)
-    print(uvf2.polarization_array)
-    print(uvf.polarization_array)
     nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
 
 
@@ -628,8 +626,6 @@ def test_collapse_pol_flag():
     print(uvf2.polarization_array)
     uvf2.collapse_pol()
     nt.assert_true(len(uvf2.polarization_array) == 1)
-    print(uvf2.polarization_array)
-    print(uvf.polarization_array)
     nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
 
 

--- a/hera_qm/tests/test_uvflag.py
+++ b/hera_qm/tests/test_uvflag.py
@@ -609,10 +609,18 @@ def test_collapse_pol():
     uvf2.polarization_array[0] = -4
     uvf.__add__(uvf2, inplace=True, axis='pol')  # Concatenate to form multi-pol object
     uvf2 = uvf.copy()
-    print(uvf2.polarization_array)
     uvf2.collapse_pol()
     nt.assert_true(len(uvf2.polarization_array) == 1)
     nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
+
+
+def test_collapse_single_pol():
+    uvf = UVFlag(test_f_file)
+    uvf.weights_array = np.ones_like(uvf.weights_array)
+    uvf2 = uvf.copy()
+    uvtest.checkWarnings(uvf.collapse_pol, [], {}, nwarnings=1,
+                         message='Cannot collapse polarization')
+    nt.assert_equal(uvf, uvf2)
 
 
 def test_collapse_pol_flag():
@@ -623,7 +631,6 @@ def test_collapse_pol_flag():
     uvf2.polarization_array[0] = -4
     uvf.__add__(uvf2, inplace=True, axis='pol')  # Concatenate to form multi-pol object
     uvf2 = uvf.copy()
-    print(uvf2.polarization_array)
     uvf2.collapse_pol()
     nt.assert_true(len(uvf2.polarization_array) == 1)
     nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))

--- a/hera_qm/tests/test_uvflag.py
+++ b/hera_qm/tests/test_uvflag.py
@@ -602,6 +602,37 @@ def test_to_waterfall_bl_multi_pol():
     nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
 
 
+def test_collapse_pol():
+    uvf = UVFlag(test_f_file)
+    uvf.weights_array = np.ones_like(uvf.weights_array)
+    uvf2 = uvf.copy()
+    uvf2.polarization_array[0] = -4
+    uvf.__add__(uvf2, inplace=True, axis='pol')  # Concatenate to form multi-pol object
+    uvf2 = uvf.copy()
+    print(uvf2.polarization_array)
+    uvf2.collapse_pol()
+    nt.assert_true(len(uvf2.polarization_array) == 1)
+    print(uvf2.polarization_array)
+    print(uvf.polarization_array)
+    nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
+
+
+def test_collapse_pol_flag():
+    uvf = UVFlag(test_f_file)
+    uvf.to_flag()
+    uvf.weights_array = np.ones_like(uvf.weights_array)
+    uvf2 = uvf.copy()
+    uvf2.polarization_array[0] = -4
+    uvf.__add__(uvf2, inplace=True, axis='pol')  # Concatenate to form multi-pol object
+    uvf2 = uvf.copy()
+    print(uvf2.polarization_array)
+    uvf2.collapse_pol()
+    nt.assert_true(len(uvf2.polarization_array) == 1)
+    print(uvf2.polarization_array)
+    print(uvf.polarization_array)
+    nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
+
+
 def test_to_waterfall_bl_flags():
     uvf = UVFlag(test_f_file)
     uvf.to_flag()

--- a/hera_qm/uvflag.py
+++ b/hera_qm/uvflag.py
@@ -428,16 +428,13 @@ class UVFlag():
         if self.type == 'waterfall' and (keep_pol or (len(self.polarization_array) == 1)):
             warnings.warn('This object is already a waterfall. Nothing to change.')
             return
+        if (not keep_pol) and (len(self.polarization_array) > 1):
+            self.collapse_pol(method)
+
         if self.mode == 'flag':
             darr = self.flag_array
         else:
             darr = self.metric_array
-        if (not keep_pol) and (len(self.polarization_array) > 1):
-            # Collapse pol dimension. But note we retain a polarization axis.
-            d, w = avg_f(darr, axis=-1, weights=self.weights_array, returned=True)
-            darr = np.expand_dims(d, axis=d.ndim)
-            self.weights_array = np.expand_dims(w, axis=w.ndim)
-            self.polarization_array = np.array([','.join(map(str, self.polarization_array))])
 
         if self.type == 'antenna':
             d, w = avg_f(darr, axis=(0, 1), weights=self.weights_array,
@@ -467,6 +464,29 @@ class UVFlag():
         self.type = 'waterfall'
         self.history += 'Collapsed to type "waterfall" with ' + hera_qm_version_str
         self.clear_unused_attributes()
+
+    def collapse_pol(self, method='quadmean'):
+        """
+        Collapse the polarization axis using a given method.
+        Args:
+            method: How to collapse the dimension(s)
+        """
+        method = method.lower()
+        avg_f = qm_utils.averaging_dict[method]
+        if self.mode == 'flag':
+            darr = self.flag_array
+        else:
+            darr = self.metric_array
+        if len(self.polarization_array) > 1:
+            # Collapse pol dimension. But note we retain a polarization axis.
+            d, w = avg_f(darr, axis=-1, weights=self.weights_array, returned=True)
+            darr = np.expand_dims(d, axis=d.ndim)
+            self.weights_array = np.expand_dims(w, axis=w.ndim)
+            self.polarization_array = np.array([','.join(map(str, self.polarization_array))])
+        if self.mode == 'flag':
+            self.flag_array = darr
+        else:
+            self.metric_array = darr
 
     def to_baseline(self, uv, force_pol=False):
         '''Convert a UVFlag object of type "waterfall" to type "baseline".

--- a/hera_qm/uvflag.py
+++ b/hera_qm/uvflag.py
@@ -483,6 +483,8 @@ class UVFlag():
             darr = np.expand_dims(d, axis=d.ndim)
             self.weights_array = np.expand_dims(w, axis=w.ndim)
             self.polarization_array = np.array([','.join(map(str, self.polarization_array))])
+        else:
+            warnings.warn('Cannot collapse polarization axis when only one pol present.')
         if self.mode == 'flag':
             self.flag_array = darr
         else:


### PR DESCRIPTION
This function allows the user to collapse the polarization dimension. Previously it was done in the `to_waterfall` function if `keep_pols == False`, but this will expose the functionality to the user.