### PR TITLE
Conform to h5py reading standards

### DIFF
--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -253,7 +253,7 @@ def _recursively_load_dict_to_group(h5file, path, group_is_ordered=False):
     """
     if group_is_ordered:
         out_dict = OrderedDict()
-        key_list = h5file[path + 'key_order'].value
+        key_list = h5file[path + 'key_order'][()]
     else:
         out_dict = {}
         key_list = list(h5file[path].keys())
@@ -266,10 +266,10 @@ def _recursively_load_dict_to_group(h5file, path, group_is_ordered=False):
 
         if isinstance(item, h5py.Dataset):
             if item.attrs['key_is_string']:
-                out_dict[str(key)] = item.value
+                out_dict[str(key)] = item[()]
             else:
                 out_key = _parse_key(key)
-                out_dict[out_key] = item.value
+                out_dict[out_key] = item[()]
 
         elif isinstance(item, h5py.Group):
             if item.attrs['key_is_string']:

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -90,7 +90,7 @@ def test_recursive_adds_numpy_array_to_h5file():
     with h5py.File(test_file, 'w') as h5_test:
         metrics_io._recursively_save_dict_to_group(h5_test, path, good_dict)
 
-        nt.assert_true(np.allclose(test_array, h5_test["0"].value))
+        nt.assert_true(np.allclose(test_array, h5_test["0"][()]))
     os.remove(test_file)
 
 
@@ -102,7 +102,7 @@ def test_recursive_adds_nested_numpy_array_to_h5file():
     good_dict = {'0': {1: test_array}}
     with h5py.File(test_file, 'w') as h5_test:
         metrics_io._recursively_save_dict_to_group(h5_test, path, good_dict)
-        nt.assert_true(np.allclose(test_array, h5_test["0/1"].value))
+        nt.assert_true(np.allclose(test_array, h5_test["0/1"][()]))
     os.remove(test_file)
 
 
@@ -115,7 +115,7 @@ def test_recursive_adds_scalar_to_h5file():
     with h5py.File(test_file, 'w') as h5_test:
         metrics_io._recursively_save_dict_to_group(h5_test, path, good_dict)
 
-        nt.assert_equal(test_scalar, h5_test["0"].value)
+        nt.assert_equal(test_scalar, h5_test["0"][()])
     os.remove(test_file)
 
 
@@ -128,7 +128,7 @@ def test_recursive_adds_nested_scalar_to_h5file():
     with h5py.File(test_file, 'w') as h5_test:
         metrics_io._recursively_save_dict_to_group(h5_test, path, good_dict)
 
-        nt.assert_equal(test_scalar, h5_test["0/1"].value)
+        nt.assert_equal(test_scalar, h5_test["0/1"][()])
     os.remove(test_file)
 
 
@@ -170,9 +170,9 @@ def test_write_metric_file_hdf5():
     metrics_io.write_metric_file(test_file, test_dict)
 
     with h5py.File(test_file, 'r') as test_h5:
-        nt.assert_equal(test_scalar, test_h5["/Metrics/0"].value)
-        nt.assert_equal(test_scalar, test_h5["/Metrics/1/0"].value)
-        nt.assert_true(np.allclose(test_array, test_h5["Metrics/1/1"].value))
+        nt.assert_equal(test_scalar, test_h5["/Metrics/0"][()])
+        nt.assert_equal(test_scalar, test_h5["/Metrics/1/0"][()])
+        nt.assert_true(np.allclose(test_array, test_h5["Metrics/1/1"][()]))
     os.remove(test_file)
 
 

--- a/hera_qm/uvflag.py
+++ b/hera_qm/uvflag.py
@@ -211,36 +211,36 @@ class UVFlag():
             with h5py.File(filename, 'r') as f:
                 header = f['/Header']
 
-                self.type = qm_utils._bytes_to_str(header['type'].value)
-                self.mode = qm_utils._bytes_to_str(header['mode'].value)
-                self.time_array = header['time_array'].value
-                self.lst_array = header['lst_array'].value
-                self.freq_array = header['freq_array'].value
-                self.history = qm_utils._bytes_to_str(header['history'].value) + ' Read by ' + hera_qm_version_str
+                self.type = qm_utils._bytes_to_str(header['type'][()])
+                self.mode = qm_utils._bytes_to_str(header['mode'][()])
+                self.time_array = header['time_array'][()]
+                self.lst_array = header['lst_array'][()]
+                self.freq_array = header['freq_array'][()]
+                self.history = qm_utils._bytes_to_str(header['history'][()]) + ' Read by ' + hera_qm_version_str
                 self.history += history
                 if 'label' in header.keys():
-                    self.label = qm_utils._bytes_to_str(header['label'].value)
-                self.polarization_array = header['polarization_array'].value
+                    self.label = qm_utils._bytes_to_str(header['label'][()])
+                self.polarization_array = header['polarization_array'][()]
                 if self.type == 'baseline':
-                    self.baseline_array = header['baseline_array'].value
-                    self.ant_1_array = header['ant_1_array'].value
-                    self.ant_2_array = header['ant_2_array'].value
+                    self.baseline_array = header['baseline_array'][()]
+                    self.ant_1_array = header['ant_1_array'][()]
+                    self.ant_2_array = header['ant_2_array'][()]
                     try:
-                        self.Nants_telescope = header['Nants_telescope'].value
+                        self.Nants_telescope = header['Nants_telescope'][()]
                     except KeyError:
                         warnings.warn('Nants_telescope not available in file, '
                                       'assuming < 2048.')
                         self.Nants_telescope = None
                 elif self.type == 'antenna':
-                    self.ant_array = header['ant_array'].value
+                    self.ant_array = header['ant_array'][()]
 
                 dgrp = f['/Data']
                 if self.mode == 'metric':
-                    self.metric_array = dgrp['metric_array'].value
+                    self.metric_array = dgrp['metric_array'][()]
                 elif self.mode == 'flag':
-                    self.flag_array = dgrp['flag_array'].value
+                    self.flag_array = dgrp['flag_array'][()]
 
-                self.weights_array = dgrp['weights_array'].value
+                self.weights_array = dgrp['weights_array'][()]
 
             self.clear_unused_attributes()
 


### PR DESCRIPTION
Replaces the `item.value` with `item[()]` when reading from hdf5 files.

Do we want to be a little more explicit with the shape in some places like was done in pyuvdata (https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/512)?

closes #247 