### PR TITLE
make uvflag inherit object

### DIFF
--- a/hera_qm/tests/test_uvflag.py
+++ b/hera_qm/tests/test_uvflag.py
@@ -1117,9 +1117,9 @@ def test_super():
         def __init__(self, input, mode='metric', copy_flags=False,
                      waterfall=False, history='', label='', property='prop'):
 
-            super(UVFlag, self).__init__(input, mode=mode, copy_flags=copy_flags,
-                                         waterfall=waterfall, history=history,
-                                         label=label)
+            super(test_class, self).__init__(input, mode=mode, copy_flags=copy_flags,
+                                             waterfall=waterfall, history=history,
+                                             label=label)
 
             self.property = property
 

--- a/hera_qm/tests/test_uvflag.py
+++ b/hera_qm/tests/test_uvflag.py
@@ -1108,3 +1108,27 @@ def test_missing_Nants_telescope():
     uvf2.Nants_telescope = None
     nt.assert_true(uvf == uvf2)
     os.remove(testfile)
+
+
+def test_super():
+
+    class test_class(UVFlag):
+
+        def __init__(self, input, mode='metric', copy_flags=False,
+                     waterfall=False, history='', label='', property='prop'):
+
+            super(UVFlag, self).__init__(input, mode=mode, copy_flags=copy_flags,
+                                         waterfall=waterfall, history=history,
+                                         label=label)
+
+            self.property = property
+
+    uv = UVData()
+    uv.read_miriad(test_d_file)
+
+    tc = test_class(uv, property='property')
+
+    # UVFlag.__init__ is tested, so just see if it has a metric array
+    nt.assert_true(hasattr(tc, 'metric_array'))
+    # Check that it has the property
+    nt.assert_true(tc.property == 'property')

--- a/hera_qm/uvflag.py
+++ b/hera_qm/uvflag.py
@@ -16,7 +16,7 @@ import copy
 from six.moves import map
 
 
-class UVFlag():
+class UVFlag(object):
     ''' Object to handle flag arrays and waterfalls. Supports reading/writing,
     and stores all relevant information to combine flags and apply to data.
     '''


### PR DESCRIPTION
`UVFlag` now properly inherits `object` as in 

`class UVFlag(object):`

Seems to pass integration checks on push.