### PR TITLE
Explicitly cast combined pol array to numpy string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda config --remove channels defaults && conda config --add channels conda-forge
+  - conda config --add channels conda-forge
   - conda install -q conda
   - conda update -q conda
   # Useful for debugging any issues with conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,9 @@ install:
   - source activate test-environment
   - conda install numpy scipy nose matplotlib astropy scikit-learn h5py coveralls aipy six pycodestyle
   - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
-  - pip install git+https://github.com/HERA-Team/omnical.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
   - pip install git+https://github.com/HERA-Team/uvtools.git
   - pip install git+https://github.com/HERA-Team/hera_cal.git
-  - python setup.py install
   - conda list
 before_script:
   - "export DISPLAY=:99.0"

--- a/hera_qm/tests/test_uvflag.py
+++ b/hera_qm/tests/test_uvflag.py
@@ -599,7 +599,7 @@ def test_to_waterfall_bl_multi_pol():
     nt.assert_true(uvf2.metric_array.shape == (len(uvf2.time_array), len(uvf.freq_array), 1))
     nt.assert_true(uvf2.weights_array.shape == uvf2.metric_array.shape)
     nt.assert_true(len(uvf2.polarization_array) == 1)
-    nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
+    nt.assert_true(uvf2.polarization_array[0] == np.string_(','.join(map(str, uvf.polarization_array))))
 
 
 def test_collapse_pol():
@@ -611,10 +611,16 @@ def test_collapse_pol():
     uvf2 = uvf.copy()
     uvf2.collapse_pol()
     nt.assert_true(len(uvf2.polarization_array) == 1)
-    nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
+    nt.assert_true(uvf2.polarization_array[0] == np.string_(','.join(map(str, uvf.polarization_array))))
     nt.assert_equal(uvf2.mode, 'metric')
     nt.assert_true(hasattr(uvf2, 'metric_array'))
     nt.assert_false(hasattr(uvf2, 'flag_array'))
+
+    # test writing it out and reading in to make sure polarization_array has correct type
+    uvf2.write(test_outfile, clobber=True)
+    uvf = UVFlag(test_outfile)
+    nt.assert_equal(uvf, uvf2)
+    os.remove(test_outfile)
 
 
 def test_collapse_pol_or():
@@ -627,7 +633,7 @@ def test_collapse_pol_or():
     uvf2 = uvf.copy()
     uvf2.collapse_pol(method='or')
     nt.assert_true(len(uvf2.polarization_array) == 1)
-    nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
+    nt.assert_true(uvf2.polarization_array[0] == np.string_(','.join(map(str, uvf.polarization_array))))
     nt.assert_equal(uvf2.mode, 'flag')
     nt.assert_true(hasattr(uvf2, 'flag_array'))
     nt.assert_false(hasattr(uvf2, 'metric_array'))
@@ -652,7 +658,7 @@ def test_collapse_pol_flag():
     uvf2 = uvf.copy()
     uvf2.collapse_pol()
     nt.assert_true(len(uvf2.polarization_array) == 1)
-    nt.assert_true(uvf2.polarization_array[0] == ','.join(map(str, uvf.polarization_array)))
+    nt.assert_true(uvf2.polarization_array[0] == np.string_(','.join(map(str, uvf.polarization_array))))
     nt.assert_equal(uvf2.mode, 'metric')
     nt.assert_true(hasattr(uvf2, 'metric_array'))
     nt.assert_false(hasattr(uvf2, 'flag_array'))

--- a/hera_qm/uvflag.py
+++ b/hera_qm/uvflag.py
@@ -543,7 +543,7 @@ class UVFlag(object):
             d, w = qm_utils.collapse(darr, method, axis=-1, weights=self.weights_array, returned=True)
             darr = np.expand_dims(d, axis=d.ndim)
             self.weights_array = np.expand_dims(w, axis=w.ndim)
-            self.polarization_array = np.array([','.join(map(str, self.polarization_array))])
+            self.polarization_array = np.array([','.join(map(str, self.polarization_array))], dtype=np.string_)
         else:
             warnings.warn('Cannot collapse polarization axis when only one pol present.')
             return


### PR DESCRIPTION
When running in python3, there was an issue where the string-ified `polarization_array` was being cast to unicode, which led to sadness when writing to hdf5. This PR explicitly casts the result to a `np.string_` datatype, which makes h5py much happier.