### PR TITLE
remove .first. from firstcal output files

### DIFF
--- a/hera_qm/firstcal_metrics.py
+++ b/hera_qm/firstcal_metrics.py
@@ -882,6 +882,8 @@ def firstcal_metrics_run(files, args, history):
             metrics_path = args.metrics_path
         print(metrics_path)
         metrics_basename = utils.strip_extension(os.path.basename(filename)) + args.extension
-        metrics_filename = os.path.join(metrics_path, metrics_basename)
+        # Sometimes the firstcal output has an extra '.first.' in the name
+        # the replace attempts to remove this but does nothing if it does not find `.first.` in the string
+        metrics_filename = os.path.join(metrics_path, metrics_basename).replace('.first.', '.')
         fm.write_metrics(filename=metrics_filename, filetype=args.filetype,
                          overwrite=args.clobber)

--- a/hera_qm/tests/test_firstcal_metrics.py
+++ b/hera_qm/tests/test_firstcal_metrics.py
@@ -270,7 +270,7 @@ class TestFirstcalMetricsRun(unittest.TestCase):
         # Test running with file
         filename = os.path.join(DATA_PATH, 'zen.2457555.50099.yy.HH.uvcA.first.calfits')
         dest_file = os.path.join(DATA_PATH, 'test_output',
-                                 'zen.2457555.50099.yy.HH.uvcA.first.'
+                                 'zen.2457555.50099.yy.HH.uvcA.'
                                  + 'firstcal_metrics.hdf5')
         if os.path.exists(dest_file):
             os.remove(dest_file)


### PR DESCRIPTION
Removes the extra .first. from fristcal_metrics output files.
Closes #260