### PR TITLE
Update XRFI Day Thresholding

### DIFF
--- a/hera_qm/tests/test_utils.py
+++ b/hera_qm/tests/test_utils.py
@@ -165,8 +165,8 @@ def test_get_metrics_ArgumentParser_day_threshold_run():
     a = utils.get_metrics_ArgumentParser('day_threshold_run')
     # First try defaults - test a few of them
     args = a.parse_args(['fooey'])
-    assert args.kt_size == 8
-    assert args.nsig_f == 5.0
+    assert args.nsig_f_adj == 3.0
+    assert args.nsig_f == 7.0
     assert args.data_files == ['fooey']
     # try to set something
     args = a.parse_args(['--nsig_t', '3.0', 'fooey'])

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -576,17 +576,6 @@ def test_watershed_flag_errors():
     pytest.raises(ValueError, xrfi.watershed_flag, uvm, uvf)
 
 
-def test_ws_flag_1D():
-    # test 1D watershed
-    metric = np.array([2., 5., 0., 2., 0., 5.])
-    fin = (metric >= 5.)
-    fout = xrfi._ws_flag_1D(metric, fin)
-    np.testing.assert_array_equal(fout, [True, True, False, False, False, True])
-
-    # catch errors
-    pytest.raises(ValueError, xrfi._ws_flag_1D, metric, fin[1:])
-
-
 def test_ws_flag_waterfall():
     # test 1d
     d = np.zeros((10,))
@@ -597,6 +586,12 @@ def test_ws_flag_waterfall():
     ans = np.zeros_like(f_out, dtype=np.bool)
     ans[:2] = True
     assert np.allclose(f_out, ans)
+
+    # another 1D test
+    metric = np.array([2., 2., 5., 0., 2., 0., 5.])
+    fin = (metric >= 5.)
+    fout = xrfi._ws_flag_waterfall(metric, fin)
+    np.testing.assert_array_equal(fout, [True, True, True, False, False, False, True])
 
     # test 2d
     d = np.zeros((10, 10))

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -576,6 +576,17 @@ def test_watershed_flag_errors():
     pytest.raises(ValueError, xrfi.watershed_flag, uvm, uvf)
 
 
+def test_ws_flag_1D():
+    # test 1D watershed
+    metric = np.array([2., 5., 0., 2., 0., 5.])
+    fin = (metric >= 5.)
+    fout = xrfi._ws_flag_1D(metric, fin)
+    np.testing.assert_array_equal(fout, [True, True, False, False, False, True])
+
+    # catch errors
+    pytest.raises(ValueError, xrfi._ws_flag_1D, metric, fin[1:])
+
+
 def test_ws_flag_waterfall():
     # test 1d
     d = np.zeros((10,))

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -1011,7 +1011,7 @@ def test_day_threshold_run(tmpdir):
     xrfi.xrfi_run(ocal_file, acal_file, model_file, data_files[1], 'Just a test',
                   kt_size=3)
 
-    xrfi.day_threshold_run(data_files, 'just a test', kt_size=3)
+    xrfi.day_threshold_run(data_files, 'just a test')
     types = ['og', 'ox', 'ag', 'ax', 'v', 'data', 'chi_sq_renormed', 'combined']
     for type in types:
         basename = '.'.join(fake_obses[0].split('.')[0:-2]) + '.' + type + '_threshold_flags.h5'

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -309,16 +309,16 @@ def get_metrics_ArgumentParser(method_name):
         ap.add_argument('data_files', type=str, nargs='+', help='List of paths to \
                         the raw data files which have been used to calibrate and \
                         rfi flag so far.')
-        ap.add_argument('--kt_size', default=8, type=int,
-                        help='Size of kernel in time dimension for detrend in xrfi '
-                        'algorithm. Default is 8.')
-        ap.add_argument('--kf_size', default=8, type=int,
-                        help='Size of kernel in frequency dimension for detrend in '
-                        'xrfi algorithm. Default is 8.')
-        ap.add_argument('--nsig_f', default=5.0, type=float,
-                        help='The number of sigma above which to flag channels. Default is 5.0.')
-        ap.add_argument('--nsig_t', default=5.0, type=float,
-                        help='The number of sigma above which to flag integrations. Default is 5.0.')
+        ap.add_argument('--nsig_f', default=7.0, type=float,
+                        help='The number of sigma above which to flag channels. Default is 7.0.')
+        ap.add_argument('--nsig_t', default=7.0, type=float,
+                        help='The number of sigma above which to flag integrations. Default is 7.0.')
+        ap.add_argument('--nsig_f_adj', default=3.0, type=float,
+                        help='The number of sigma above which to flag channels if they neighbor \
+                        flagged channels. Default is 3.0.')
+        ap.add_argument('--nsig_t_adj', default=3.0, type=float,
+                        help='The number of sigma above which to flag integrations if they neighbor \
+                        flagged integrations. Default is 7.0.')
         ap.add_argument("--clobber", default=False, action="store_true",
                         help='If True, overwrite existing files. Default is False.')
         ap.add_argument("--run_if_first", default=None, type=str, help='only run \

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1492,8 +1492,8 @@ def xrfi_run(ocalfits_file, acalfits_file, model_file, data_file, history,
         uvf.write(outpath, clobber=clobber)
 
 
-def day_threshold_run(data_files, history, kt_size=8, kf_size=8, nsig_f=5.0, nsig_t=5.0,
-                      clobber=False):
+def day_threshold_run(data_files, history, nsig_f=7., nsig_t=7.,
+                      nsig_f_adj=3., nsig_t_adj=3., clobber=False):
     """Apply thresholding across all times/frequencies, using a full day of data.
 
     This function will write UVFlag files for each data input (omnical gains,
@@ -1512,16 +1512,13 @@ def day_threshold_run(data_files, history, kt_size=8, kf_size=8, nsig_f=5.0, nsi
         Paths to the raw data files which have been used to calibrate and rfi flag so far.
     history : str
         The history string to include in files.
-    kt_size : int, optional
-        The size of kernel in time dimension for detrend in xrfi algorithm.
-        Default is 8.
-    kf_size : int, optional
-        Size of kernel in frequency dimension for detrend in xrfi algorithm.
-        Default is 8.
     nsig_f : float, optional
-        The number of sigma above which to flag channels. Default is 5.0.
+        The number of sigma above which to flag channels. Default is 7.0.
     nsig_t : float, optional
-        The number of sigma above which to flag integrations. Default is 5.0.
+        The number of sigma above which to flag integrations. Default is 7.0.
+    nsig_f_adj : float, optional
+        The number of sigma above which to flag channels if they neighbor flagged channels.
+        Default is 3.0.
     nsig_t_adj : float, optional
         The number of sigma above which to flag integrations if they neighbor flagged integrations.
         Default is 3.0.
@@ -1563,7 +1560,8 @@ def day_threshold_run(data_files, history, kt_size=8, kf_size=8, nsig_f=5.0, nsi
     uvf_total = filled_metrics[0].copy()
     uvf_total.to_flag()
     for i, uvf_m in enumerate(filled_metrics):
-        uvf_f = threshold_wf(uvf_m, nsig_f=nsig_f, nsig_t=nsig_t, detrend=False)
+        uvf_f = threshold_wf(uvf_m, nsig_f=nsig_f, nsig_t=nsig_t,
+                             nsig_f_adj=nsig_f_adj, nsig_t_adj=nsig_t_adj, detrend=False)
         outfile = '.'.join([basename, types[i] + '_threshold_flags.h5'])
         outpath = os.path.join(outdir, outfile)
         uvf_f.write(outpath, clobber=clobber)

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -729,7 +729,7 @@ def _ws_flag_waterfall(data, fin, nsig=2.):
             for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
                 xp, yp = ((foutx + dx).clip(0, fout.shape[0] - 1),
                           (fouty + dy).clip(0, fout.shape[1] - 1))
-                ind = np.where(data[xp, yp] > nsig)[0]  # if our metric > sig
+                ind = np.where(np.abs(data[xp, yp]) >= nsig)[0]  # if our metric > sig
                 fout[xp[ind], yp[ind]] = 1
                 foutx, fouty = np.where(fout)
     else:

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1519,11 +1519,7 @@ def day_threshold_run(data_files, history, kt_size=8, kf_size=8, nsig_f=5.0, nsi
     uvf_total = filled_metrics[0].copy()
     uvf_total.to_flag()
     for i, uvf_m in enumerate(filled_metrics):
-        if types[i] == 'chi_sq_renormed':
-            detrend = False
-        else:
-            detrend = True
-        uvf_f = threshold_wf(uvf_m, nsig_f=nsig_f, nsig_t=nsig_t, detrend=detrend)
+        uvf_f = threshold_wf(uvf_m, nsig_f=nsig_f, nsig_t=nsig_t, detrend=False)
         outfile = '.'.join([basename, types[i] + '_threshold_flags.h5'])
         outpath = os.path.join(outdir, outfile)
         uvf_f.write(outpath, clobber=clobber)

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -706,6 +706,8 @@ def _ws_flag_waterfall(metric, fin, nsig=2.):
         equal to 1 or 2, a ValueError is raised.
 
     """
+    # Delay import so scipy is not required for use of hera_qm
+    from scipy.signal import convolve
     if metric.shape != fin.shape:
         raise ValueError('metric and fin must match in shape. Shapes are: ' + str(metric.shape)
                          + ' and ' + str(fin.shape))
@@ -716,7 +718,7 @@ def _ws_flag_waterfall(metric, fin, nsig=2.):
             kernel = {1: [1, 0, 1], 2: [[0, 1, 0], [1, 0, 1], [0, 1, 0]]}[metric.ndim]
         except KeyError:
             raise ValueError('Data must be 1D or 2D.')
-        is_neighbor_flagged = np.convolve(fout, kernel, mode='same').astype(bool)
+        is_neighbor_flagged = convolve(fout, kernel, mode='same', method='direct').astype(bool)
         fout |= (is_neighbor_flagged & (metric >= nsig))
         if np.sum(fout) == nflags:
             break

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -718,7 +718,7 @@ def _ws_flag_waterfall(metric, fin, nsig=2.):
             kernel = {1: [1, 0, 1], 2: [[0, 1, 0], [1, 0, 1], [0, 1, 0]]}[metric.ndim]
         except KeyError:
             raise ValueError('Data must be 1D or 2D.')
-        is_neighbor_flagged = convolve(fout, kernel, mode='same', method='direct').astype(bool)
+        is_neighbor_flagged = convolve(fout, kernel, mode='same').astype(bool)
         fout |= (is_neighbor_flagged & (metric >= nsig))
         if np.sum(fout) == nflags:
             break

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -909,9 +909,9 @@ def threshold_wf(uvf_m, nsig_f=7., nsig_t=7., nsig_f_adj=3., nsig_t_adj=3., detr
     tseries = np.ma.median(data, axis=(1, 2))
     ztseries = modzscore_1d(tseries, detrend=detrend)
     # Flag based on zscores and thresholds
-    f_flags = _ws_flag_1D(zspec, np.abs(zspec) >= nsig_f, nsig=nsig_f_adj)
+    f_flags = _ws_flag_waterfall(np.abs(zspec), np.abs(zspec) >= nsig_f, nsig=nsig_f_adj)
     uvf_f.flag_array[:, f_flags, :] = True
-    t_flags = _ws_flag_1D(ztseries, np.abs(ztseries) >= nsig_t, nsig=nsig_t_adj)
+    t_flags = _ws_flag_waterfall(np.abs(ztseries), np.abs(ztseries) >= nsig_t, nsig=nsig_t_adj)
     uvf_f.flag_array[t_flags, :, :] = True
 
     return uvf_f

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -679,6 +679,38 @@ def watershed_flag(uvf_m, uvf_f, nsig_p=2., nsig_f=None, nsig_t=None, avg_method
     return uvf
 
 
+def _ws_flag_1D(metric, fin, nsig=2.):
+    """Perform the watershed algorithm in 1D, given input metric and flags.
+
+    Parameters
+    ----------
+    metric : array
+        A 1D array. Should be in units of standard deviations.
+    fin : array
+        The input boolean flags used as the seed of the watershed. Same size as metric.
+    nsig : float, optional
+        The number of sigma to flag above for points next to flagged points. Default is 2.
+
+    Returns
+    -------
+    fout : array
+        An boolean array of fin OR the watershedded flags. Same shape as fin.
+
+    Raises
+    ------
+    ValueError:
+        If the shapes of metric and fin do not match a ValueError is raised.
+
+    """
+    if metric.shape != fin.shape:
+            raise ValueError('metric and fin must match in shape. Shapes are: ' + str(metric.shape)
+                             + ' and ' + str(fin.shape))
+    # determine which indices are next to one or more flags
+    is_neighbor_flagged = np.convolve(fin, [1, 0, 1], mode='same').astype(bool)
+    fout = fin | (is_neighbor_flagged & (np.abs(metric) >= nsig))
+    return fout
+
+
 def _ws_flag_waterfall(data, fin, nsig=2.):
     """Perform the watershed algorithm on 1D or 2D arrays of metric and input flags.
 

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -703,8 +703,8 @@ def _ws_flag_1D(metric, fin, nsig=2.):
 
     """
     if metric.shape != fin.shape:
-            raise ValueError('metric and fin must match in shape. Shapes are: ' + str(metric.shape)
-                             + ' and ' + str(fin.shape))
+        raise ValueError('metric and fin must match in shape. Shapes are: ' + str(metric.shape)
+                         + ' and ' + str(fin.shape))
     # determine which indices are next to one or more flags
     is_neighbor_flagged = np.convolve(fin, [1, 0, 1], mode='same').astype(bool)
     fout = fin | (is_neighbor_flagged & (np.abs(metric) >= nsig))

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -722,14 +722,14 @@ def _ws_flag_waterfall(data, fin, nsig=2.):
     data : array
         A 2D or 1D array. Should be in units of standard deviations.
     fin : array
-        The input (boolean) flags used as the seed of the watershed. Same size as d.
+        The input (boolean) flags used as the seed of the watershed. Same size as data.
     nsig : float, optional
         The number of sigma to flag above for points near flagged points. Default is 2.
 
     Returns
     -------
     fout : array
-        A boolean array matching size of d and fin, with watershedded flags.
+        A boolean array matching size of data and fin, with watershedded flags.
 
     Raises
     ------

--- a/scripts/xrfi_day_threshold_run.py
+++ b/scripts/xrfi_day_threshold_run.py
@@ -12,8 +12,7 @@ args = ap.parse_args()
 history = ' '.join(sys.argv)
 
 if args.run_if_first is None or sorted(args.data_files)[0] == args.run_if_first:
-    xrfi.day_threshold_run(args.data_files, history, kt_size=args.kt_size,
-                           kf_size=args.kf_size, nsig_f=args.nsig_f, nsig_t=args.nsig_t,
-                           clobber=args.clobber)
+    xrfi.day_threshold_run(args.data_files, history, nsig_f=args.nsig_f, nsig_t=args.nsig_t,
+                           nsig_f_adj=args.nsig_f_adj, nsig_t_adj=args.nsig_t_adj, clobber=args.clobber)
 else:
     print(sorted(args.data_files)[0], 'is not', args.run_if_first, '...skipping.')


### PR DESCRIPTION
Modifies xrfi day-thresholding (which flags entire channels and entire times based on z-scores of median metrics over the other dimension) in three ways:

1. Removes detrending of 1D median metrics when computing modified z-scores from median-ed metrics. This detrending was creating problems where times that were almost entirely flagged by the original metrics waterfalls didn't trigger the threshold because the median metric of neighboring times were noisy, suppressing the apparent outlierness. This was discussed on the 7/18/19 QM telecon.
2. Adds a 1D watershed algorithm to thresholding. Now moderately bad channels/integrations next to very bad channels/integrations also get flagged.
3. Bumps up the default thresholds to 7 sigma and 3 sigma for neighbors in the watershed.