### PR TITLE
CI dependency workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - conda install numpy scipy matplotlib astropy scikit-learn h5py coveralls aipy six pycodestyle pydocstyle pytest-cov
   - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
-  - pip install --no-dependencies git+https://github.com/HERA-Team/uvtools.git
+  - pip install git+https://github.com/HERA-Team/uvtools.git
   - pip install git+https://github.com/HERA-Team/hera_cal.git
   - conda list
 before_script:


### PR DESCRIPTION
with new aipy pypi version we should be able to remove the uvtools install workaround.

closes #292 