### PR TITLE
Fix Current Errors in Warnings Counting

### DIFF
--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -425,7 +425,7 @@ def test_run_ant_metrics_one_file():
 
     # test error
     with pytest.raises(AssertionError, match='Could not find'):
-        ant_metrics.ant_metrics_run(args.files, pols, args.crossCut, 
+        ant_metrics.ant_metrics_run(args.files, pols, args.crossCut,
                                     args.deadCut, args.alwaysDeadCut,
                                     args.metrics_path,
                                     args.extension, args.vis_format,

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -423,17 +423,13 @@ def test_run_ant_metrics_one_file():
     history = cmd
     pols = list(args.pol.split(','))
 
-    # this test raises a warning, then fails...
-    uvtest.checkWarnings(pytest.raises,
-                         [AssertionError, ant_metrics.ant_metrics_run,
-                          args.files, pols, args.crossCut,
-                          args.deadCut, args.alwaysDeadCut,
-                          args.metrics_path,
-                          args.extension, args.vis_format,
-                          args.verbose, history, args.run_cross_pols],
-                         nwarnings=1,
-                         message='Could not find')
-
+    # test error
+    with pytest.raises(AssertionError, match='Could not find'):
+        ant_metrics.ant_metrics_run(args.files, pols, args.crossCut, 
+                                    args.deadCut, args.alwaysDeadCut,
+                                    args.metrics_path,
+                                    args.extension, args.vis_format,
+                                    args.verbose, history, args.run_cross_pols)
 
 def test_ant_metrics_run_no_cross_pols():
     # get arguments

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -431,6 +431,7 @@ def test_run_ant_metrics_one_file():
                                     args.extension, args.vis_format,
                                     args.verbose, history, args.run_cross_pols)
 
+
 def test_ant_metrics_run_no_cross_pols():
     # get arguments
     a = utils.get_metrics_ArgumentParser('ant_metrics')

--- a/hera_qm/tests/test_utils.py
+++ b/hera_qm/tests/test_utils.py
@@ -75,9 +75,8 @@ def test_generate_fullpol_file_list():
 
     # try to pass in a file that doesn't have all pols present
     lone_file = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA')
-    fullpol_file_list = uvtest.checkWarnings(utils.generate_fullpol_file_list,
-                                             [[lone_file], pol_list], nwarnings=1,
-                                             message='Could not find')
+    with pytest.warns(UserWarning, match='Could not find'):
+        fullpol_file_list = utils.generate_fullpol_file_list([lone_file], pol_list)
     assert fullpol_file_list == []
 
 

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -917,7 +917,6 @@ def test_xrfi_run(tmpdir):
             n_matched_warnings += 1
     assert n_matched_warnings == 6
 
-                         # nwarnings=len(messages), message=messages, category=categories)
     # remove spoofed files
     for fname in [ocal_file, acal_file, model_file, raw_dfile]:
         os.remove(fname)

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -906,9 +906,18 @@ def test_xrfi_run(tmpdir):
     shutil.copyfile(test_uvh5_file, raw_dfile)
     model_file = os.path.join(tmp_path, fake_obs + '.omni_vis.uvh5')
     shutil.copyfile(test_uvh5_file, model_file)
-    uvtest.checkWarnings(xrfi.xrfi_run, [ocal_file, acal_file, model_file,
-                                         raw_dfile, 'Just a test'], {'kt_size': 3, 'ant_str': 'cross'},
-                         nwarnings=len(messages), message=messages, category=categories)
+    
+    # check warnings
+    with pytest.warns(None) as record:
+        xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, 'Just a test', kt_size=3, ant_str='cross')
+    assert len(record) >= len(messages)
+    n_matched_warnings = 0
+    for i in range(len(record)):
+        if mess1[0] in str(record[i].message) and cat1[0] == record[i].category:
+            n_matched_warnings += 1
+    assert n_matched_warnings == 6
+
+                         # nwarnings=len(messages), message=messages, category=categories)
     # remove spoofed files
     for fname in [ocal_file, acal_file, model_file, raw_dfile]:
         os.remove(fname)
@@ -975,9 +984,17 @@ def test_day_threshold_run(tmpdir):
     data_files = [raw_dfile]
     model_file = os.path.join(tmp_path, fake_obses[0] + '.omni_vis.uvh5')
     shutil.copyfile(test_uvh5_file, model_file)
-    uvtest.checkWarnings(xrfi.xrfi_run, [ocal_file, acal_file, model_file,
-                                         raw_dfile, 'Just a test'], {'kt_size': 3},
-                         nwarnings=len(messages), message=messages, category=categories)
+
+    # check warnings
+    with pytest.warns(None) as record:
+        xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, 'Just a test', kt_size=3)
+    assert len(record) >= len(messages)
+    n_matched_warnings = 0
+    for i in range(len(record)):
+        if mess1[0] in str(record[i].message) and cat1[0] == record[i].category:
+            n_matched_warnings += 1
+    assert n_matched_warnings == 6
+
     # Need to adjust time arrays when duplicating files
     uvd = UVData()
     uvd.read_uvh5(data_files[0])
@@ -996,9 +1013,16 @@ def test_day_threshold_run(tmpdir):
     uvc.write_calfits(ocal_file)
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
     uvc.write_calfits(acal_file)
-    uvtest.checkWarnings(xrfi.xrfi_run, [ocal_file, acal_file, model_file,
-                                         data_files[1], 'Just a test'], {'kt_size': 3},
-                         nwarnings=len(messages), message=messages, category=categories)
+
+    # check warnings
+    with pytest.warns(None) as record:
+        xrfi.xrfi_run(ocal_file, acal_file, model_file, data_files[1], 'Just a test', kt_size=3, clobber=True)
+    assert len(record) >= len(messages)
+    n_matched_warnings = 0
+    for i in range(len(record)):
+        if mess1[0] in str(record[i].message) and cat1[0] == record[i].category:
+            n_matched_warnings += 1
+    assert n_matched_warnings == 6
 
     xrfi.day_threshold_run(data_files, 'just a test')
     types = ['og', 'ox', 'ag', 'ax', 'v', 'data', 'chi_sq_renormed', 'combined']
@@ -1019,11 +1043,16 @@ def test_xrfi_h1c_run():
                       kt_size=3)
 
     # catch no provided data file for flagging
-    uvtest.checkWarnings(xrfi.xrfi_h1c_run, [None],
-                         {'filename': test_d_file, 'history': 'Just a test.',
-                          'model_file': test_d_file, 'model_file_format': 'miriad',
-                          'xrfi_path': xrfi_path}, nwarnings=191,
-                         message=['indata is None'] + 190 * ['K1 value 8'])
+    with pytest.warns(None) as record:
+        xrfi.xrfi_h1c_run(None, **{'filename': test_d_file, 'history': 'Just a test.',
+                                   'model_file': test_d_file, 'model_file_format': 'miriad',
+                                   'xrfi_path': xrfi_path})
+    assert len(record) >= 191
+    n_matched_warnings = 0
+    for i in range(len(record)):
+        if 'indata is None' in str(record[i].message) or 'K1 value 8' in str(record[i].message):
+            n_matched_warnings += 1
+    assert n_matched_warnings == 191
 
 
 def test_xrfi_h1c_run_no_indata():

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -906,7 +906,7 @@ def test_xrfi_run(tmpdir):
     shutil.copyfile(test_uvh5_file, raw_dfile)
     model_file = os.path.join(tmp_path, fake_obs + '.omni_vis.uvh5')
     shutil.copyfile(test_uvh5_file, model_file)
-    
+
     # check warnings
     with pytest.warns(None) as record:
         xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, 'Just a test', kt_size=3, ant_str='cross')


### PR DESCRIPTION
I've replaced the currently broken calls to `pyuvdata.tests.checkWarnings` by just using pytest directly. Instead of checking that precisely N warnings were issued matching certain criteria, I just made it so at least N such warnings were issued, allowing for other warnings to crop up.

This resolves #343.