### PR TITLE
Fix flag end integrations

### DIFF
--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -1184,6 +1184,138 @@ def test_xrfi_run(tmpdir):
     for fname in [ocal_file, acal_file, model_file, raw_dfile]:
         os.remove(fname)
 
+def test_xrfi_run_edgeflag(tmpdir):
+    # test that flags within kt_size are flagged.
+    # first try out a single file.
+    # The warnings are because we use UVFlag.to_waterfall() on the total chisquareds
+    # This doesn't hurt anything, and lets us streamline the pipe
+    mess1 = ['This object is already a waterfall']
+    messages = 8 * mess1
+    cat1 = [UserWarning]
+    categories = 8 * cat1
+    # Spoof a couple files to use as extra inputs (xrfi_run needs two cal files and two data-like files)
+    tmp_path = tmpdir.strpath
+    fake_obs = 'zen.2457698.40355.HH'
+    ocal_file = os.path.join(tmp_path, fake_obs + '.omni.calfits')
+    shutil.copyfile(test_c_file, ocal_file)
+    acal_file = os.path.join(tmp_path, fake_obs + '.abs.calfits')
+    shutil.copyfile(test_c_file, acal_file)
+    raw_dfile = os.path.join(tmp_path, fake_obs + '.uvh5')
+    shutil.copyfile(test_uvh5_file, raw_dfile)
+    model_file = os.path.join(tmp_path, fake_obs + '.omni_vis.uvh5')
+    shutil.copyfile(test_uvh5_file, model_file)
+    # check warnings
+    with pytest.warns(None) as record:
+        xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, 'Just a test', kt_size=2)
+    assert len(record) >= len(messages)
+    n_matched_warnings = 0
+    for i in range(len(record)):
+        if mess1[0] in str(record[i].message) and cat1[0] == record[i].category:
+            n_matched_warnings += 1
+    assert n_matched_warnings == 8
+    outdir = os.path.join(tmp_path, 'zen.2457698.40355.xrfi')
+    ext_labels = {'ag_flags1': 'Abscal gains, median filter. Flags.',
+                  'ag_flags2': 'Abscal gains, mean filter. Flags.',
+                  'ag_metrics1': 'Abscal gains, median filter.',
+                  'ag_metrics2': 'Abscal gains, mean filter.',
+                  'apriori_flags': 'A priori flags.',
+                  'ax_flags1': 'Abscal chisq, median filter. Flags.',
+                  'ax_flags2': 'Abscal chisq, mean filter. Flags.',
+                  'ax_metrics1': 'Abscal chisq, median filter.',
+                  'ax_metrics2': 'Abscal chisq, mean filter.',
+                  'omnical_chi_sq_flags1': 'Omnical Renormalized chisq, median filter. Flags.',
+                  'omnical_chi_sq_flags2': 'Omnical Renormalized chisq, median filter, round 2. Flags.',
+                  'omnical_chi_sq_renormed_metrics1': 'Omnical Renormalized chisq, median filter.',
+                  'omnical_chi_sq_renormed_metrics2': 'Omnical Renormalized chisq, median filter, round 2.',
+                  'abscal_chi_sq_flags1': 'Abscal Renormalized chisq, median filter. Flags.',
+                  'abscal_chi_sq_flags2': 'Abscal Renormalized chisq, median filter, round 2. Flags.',
+                  'abscal_chi_sq_renormed_metrics1': 'Abscal Renormalized chisq, median filter.',
+                  'abscal_chi_sq_renormed_metrics2': 'Abscal Renormalized chisq, median filter, round 2.',
+                  'combined_flags1': 'Flags from combined metrics, round 1.',
+                  'combined_flags2': 'Flags from combined metrics, round 2.',
+                  'combined_metrics1': 'Combined metrics, round 1.',
+                  'combined_metrics2': 'Combined metrics, round 2.',
+                  'cross_flags1': 'Crosscorr, median filter. Flags.',
+                  'cross_flags2': 'Crosscorr, mean filter. Flags.',
+                  'auto_flags1': 'Autocorr, median filter. Flags.',
+                  'auto_flags2': 'Autocorr, mean filter. Flags.',
+                  'auto_metrics2': 'Autocorr, mean filter.',
+                  'auto_metrics1': 'Autocorr, median filter.',
+                  'cross_metrics2': 'Crosscorr, mean filter.',
+                  'cross_metrics1': 'Crosscorr, median filter.',
+                  'flags1': 'ORd flags, round 1.',
+                  'flags2': 'ORd flags, round 2.',
+                  'og_flags1': 'Omnical gains, median filter. Flags.',
+                  'og_flags2': 'Omnical gains, mean filter. Flags.',
+                  'og_metrics1': 'Omnical gains, median filter.',
+                  'og_metrics2': 'Omnical gains, mean filter.',
+                  'ox_flags1': 'Omnical chisq, median filter. Flags.',
+                  'ox_flags2': 'Omnical chisq, mean filter. Flags.',
+                  'ox_metrics1': 'Omnical chisq, median filter.',
+                  'ox_metrics2': 'Omnical chisq, mean filter.',
+                  'v_flags1': 'Omnical visibility solutions, median filter. Flags.',
+                  'v_flags2': 'Omnical visibility solutions, mean filter. Flags.',
+                  'v_metrics1': 'Omnical visibility solutions, median filter.',
+                  'v_metrics2': 'Omnical visibility solutions, mean filter.'}
+    for ext, label in ext_labels.items():
+        # by default, only cross median filter / mean filter is not performed.
+        if not ext in['cross_metrics1', 'cross_flags1']:
+            out = os.path.join(outdir, '.'.join([fake_obs, ext, 'h5']))
+            assert os.path.exists(out)
+            uvf = UVFlag(out)
+            if ext == 'flags2.h5':
+                # check that two within edges are flagged
+                assert np.all(uvf.flag_array[:2])
+                assert np.all(uvf.flag_array[-2:])
+                # check that there are is some unflagged data in between
+                assert not np.all(uvf.flag_array[2:-2])
+
+    # cleanup
+    for ext, label in ext_labels.items():
+        out = os.path.join(outdir, '.'.join([fake_obs, ext, 'h5']))
+        if os.path.exists(out):
+            os.remove(out)
+    # now try two different files.
+    fake_obses = ['zen.2457698.40355191.HH', 'zen.2457698.40367619.HH', 'zen.2457698.40380046.HH']
+    # Spoof a couple files to use as extra inputs (xrfi_run needs two cal files and two data-like files)
+    tmp_path = tmpdir.strpath
+    fake_obses = ['zen.2457698.40355191.HH', 'zen.2457698.40367619.HH', 'zen.2457698.40380046.HH']
+    ocal_files = []
+    acal_files = []
+    model_files =[]
+    raw_dfiles = []
+    for uvf, cf, fo in zip(test_uvh5_files, test_c_files, fake_obses):
+        ocal_file = os.path.join(tmp_path, fo + '.omni.calfits')
+        shutil.copyfile(cf, ocal_file)
+        ocal_files.append(ocal_file)
+        acal_file = os.path.join(tmp_path, fo + '.abs.calfits')
+        shutil.copyfile(cf, acal_file)
+        acal_files.append(acal_file)
+        raw_dfile = os.path.join(tmp_path, fo + '.uvh5')
+        shutil.copyfile(uvf, raw_dfile)
+        raw_dfiles.append(raw_dfile)
+        model_file = os.path.join(tmp_path, fo + '.omni_vis.uvh5')
+        shutil.copyfile(uvf, model_file)
+        model_files.append(model_file)
+    with pytest.warns(None) as record:
+        xrfi.xrfi_run(ocal_files, acal_files, model_files, raw_dfiles, 'Just a test', kt_size=1)
+    assert len(record) >= len(messages)
+    n_matched_warnings = 0
+    for i in range(len(record)):
+        if mess1[0] in str(record[i].message) and cat1[0] == record[i].category:
+            n_matched_warnings += 1
+    assert n_matched_warnings == 8
+    flags2 = sorted(glob.glob(tmp_path + '/*.xrfi/*.HH.flags2.h5'))
+    assert len(flags2) == 3
+    uvf = UVFlag(flags2)
+    # check that two within edges are flagged
+    assert np.all(uvf.flag_array[:1])
+    assert np.all(uvf.flag_array[-1:])
+    # check that there are is some unflagged data in between
+    assert not np.all(uvf.flag_array[1:-1])
+
+
+
 def test_xrfi_run_multifile(tmpdir):
     # test xrfi_run with multiple files
     # The warnings are because we use UVFlag.to_waterfall() on the total chisquareds

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -2051,7 +2051,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None, data_fi
                                      inplace=False)
                 # Determine indices relative to zero below and above which to flag edges.
                 # flag all integrations above Ntimes - (kernel size - ntimes x (number of files to end of night)
-                lower_flag_ind = np.max([uvtemp.Ntimes - (kt_size - uvtemp.Ntimes * (len(uvlist) - 1 - night_index)), 0])
+                lower_flag_ind = np.max([uvtemp.Ntimes - (kt_size - uvtemp.Ntimes * (len(all_files) - 1 - night_index)), 0])
                 # flag all integrations below kernel_size - ntimes x (number of files from beginning of night)
                 upper_flag_ind = np.max([kt_size - uvtemp.Ntimes * night_index, 0])
                 if throw_away_edges:

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -2053,12 +2053,12 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None, data_fi
                 # flag all integrations above Ntimes - (kernel size - ntimes x (number of files to end of night)
                 lower_flag_ind = np.max([uvtemp.Ntimes - (kt_size - uvtemp.Ntimes * (len(all_files) - 1 - night_index)), 0])
                 # flag all integrations below kernel_size - ntimes x (number of files from beginning of night)
-                upper_flag_ind = np.max([kt_size - uvtemp.Ntimes * night_index, 0])
+                upper_flag_ind = np.min([np.max([kt_size - uvtemp.Ntimes * night_index, 0]), uvtemp.Ntimes])
                 if throw_away_edges:
                     if (ext == 'flags2.h5'):
                         if lower_flag_ind < uvtemp.Ntimes and lower_flag_ind >=  0:
                             uvf_out.flag_array[lower_flag_ind:] = True
-                        if upper_flag_ind <= uvtemp.Ntimes and upper_flag_ind > 0:
+                        if upper_flag_ind > 0:
                             uvf_out.flag_array[:upper_flag_ind] = True
                 outfile = '.'.join([basename, ext])
                 outpath = os.path.join(dirname, outfile)

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -2052,12 +2052,14 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None, data_fi
                 uvf_out = uvf.select(times=this_times[t_ind:(t_ind + uvtemp.Ntimes)],
                                      inplace=False)
                 # Determine indices relative to zero below and above which to flag edges.
-                lower_flag_ind = np.max([uvtemp.Ntimes - (kt_size - uvtemp.Ntimes * (len(uvlist) - 1 - ind)) - 1, 0])
-                upper_flag_ind = np.max([uvtemp.Ntimes - (kt_size - uvtemp.Ntimes * ind) - 1, 0])
+                # flag all integrations above Ntimes - (kernel size - ntimes x (number of files to end)
+                lower_flag_ind = np.max([uvtemp.Ntimes - (kt_size - uvtemp.Ntimes * (len(uvlist) - 1 - ind)), 0])
+                # flag all integrations below kernel_size - ntimes x (number of files from beginning)
+                upper_flag_ind = np.max([kt_size - uvtemp.Ntimes * ind, 0])
                 if (ext == 'flags2.h5'):
                     if lower_flag_ind < uvtemp.Ntimes and lower_flag_ind >=  0:
                         uvf_out.flag_array[lower_flag_ind:] = True
-                    if upper_flag_ind < uvtemp.Ntimes and lower_flag_ind >= 0:
+                    if upper_flag_ind <= uvtemp.Ntimes and upper_flag_ind > 0:
                         uvf_out.flag_array[:upper_flag_ind] = True
                 outfile = '.'.join([basename, ext])
                 outpath = os.path.join(dirname, outfile)


### PR DESCRIPTION
Fixes #354  bug where the incorrect number of flags were being applied from the end of the day. 

Also supports flagging subset of integrations when the time kernel size is not an integer multiple of the number of integrations per file.