### PR TITLE
Add support for a priori flagging YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ required dependencies. See below for manual dependency management.
 If you are using `conda`, you may wish to install the following dependencies manually
 to avoid them being installed automatically by `pip`::
 
-    $ conda install -c conda-forge "numpy>=1.10" "astropy>=3.2.3" "aipy>=3.0rc2" h5py pyuvdata
+    $ conda install -c conda-forge "numpy>=1.10" "astropy>=3.2.3" "aipy>=3.0rc2" h5py pyuvdata pyyaml
 
 ### Developing
 If you are developing `hera_qm`, it is preferred that you do so in a fresh `conda`

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pytest
   - scikit-learn # from hera_cal
   - pytest-cov
+  - pyyaml
   - pip:
     - git+https://github.com/HERA-Team/uvtools
     - git+https://github.com/HERA-Team/hera_cal

--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -598,8 +598,8 @@ class AntennaMetrics():
         metrics_io.write_metric_file(filename, out_dict, overwrite=overwrite)
 
 
-def ant_metrics_run(data_files, apriori_xants=[], crossCut=5.0, deadCut=5.0,
-                    run_cross_pols=True, run_cross_pols_only=False,
+def ant_metrics_run(data_files, apriori_xants=[], a_priori_xants_yaml=None,
+                    crossCut=5.0, deadCut=5.0, run_cross_pols=True, run_cross_pols_only=False,
                     metrics_path='', extension='.ant_metrics.hdf5',
                     overwrite=False, Nbls_per_load=None, history='', verbose=True):
     """
@@ -619,6 +619,10 @@ def ant_metrics_run(data_files, apriori_xants=[], crossCut=5.0, deadCut=5.0,
         List of integer antenna numbers or antpol tuples e.g. (0, 'Jee') to mark
         as excluded apriori. These are included in self.xants, but not
         self.dead_ants or self.crossed_ants when writing results to disk.
+    a_priori_xants_yaml : string, optional
+        Path to a priori flagging YAML with antenna flagging information.
+        See hera_qm.metrics_io.read_a_priori_ant_flags() for details.
+        Frequency and time flags in the YAML are ignored.
     crossCut : float, optional
             Modified Z-Score limit to cut cross-polarized antennas. Default is 5.0.
     deadCut : float, optional
@@ -643,6 +647,11 @@ def ant_metrics_run(data_files, apriori_xants=[], crossCut=5.0, deadCut=5.0,
     verbose : bool, optional
         If True, print out statements during iterative flagging. Default is True.
     """
+
+    # load a priori exants from YAML and append to apriori_xants
+    if a_priori_xants_yaml is not None:
+        apaf = metrics_io.read_a_priori_ant_flags(a_priori_xants_yaml)
+        apriori_xants = list(set(list(apriori_xants) + apaf))
 
     # run ant metrics
     am = AntennaMetrics(data_files,

--- a/hera_qm/data/a_priori_flags_old_pols.yaml
+++ b/hera_qm/data/a_priori_flags_old_pols.yaml
@@ -1,0 +1,42 @@
+# A PRIORI FLAGS
+
+# The following flags can be loaded by functions in hera_qm.metrics_io, including:
+# read_a_priori_chan_flags(), read_a_priori_int_flags(), and read_a_priori_ant_flags().
+# Variable names are hard-coded and cannot be changed without unexpected behavior.
+
+# ---------------
+# FREQUENCY FLAGS
+# ---------------
+
+# freq_flags are an array of length-2 arrays of floats in units of Hz (freq ranges, inclusive)
+freq_flags: [[0, 110e6], 
+             [150e6, 155e6],
+             [190e6, 200e6]]
+
+# channel_flags are an array of ints or length-2 arrays of ints (channel ranges, inclusive)
+channel_flags: [0, 1, [10, 20], 60]
+
+
+# ---------------
+# TIME FLAGS
+# ---------------
+
+# # JD_flags are an array of length-2 arrays of floats in units of days (time ranges, inclusive)
+JD_flags: [[2458838.01, 2458838.03]]
+
+# LST_flags are an array of length-2 arrays of floats in units of hours (time ranges, inclusive).
+# If LST_1 > LST_2, it's assumed to span the 24 branch cut.
+LST_flags: [[2.3, 3.5],
+            [16.2, 18.4], 
+            [23.4, 0.1]]
+
+# integration_flags are an array of ints or length-2 arrays of ints (integration ranges, inclusive)
+integration_flags: [0, 1, [10, 20], 59]
+
+
+# ---------------
+# ANTENNA FLAGS
+# ---------------
+
+# ex_ants is an array of integer antennas or length-2 arrays of integer antennas and string antpols
+ex_ants: [0, 10, [1, Jxx], [3, Jyy]]

--- a/hera_qm/data/a_priori_flags_sample.yaml
+++ b/hera_qm/data/a_priori_flags_sample.yaml
@@ -1,0 +1,42 @@
+# A PRIORI FLAGS
+
+# The following flags can be loaded by functions in hera_qm.metrics_io, including:
+# read_a_priori_chan_flags(), read_a_priori_int_flags(), and read_a_priori_ant_flags().
+# Variable names are hard-coded and cannot be changed without unexpected behavior.
+
+# ---------------
+# FREQUENCY FLAGS
+# ---------------
+
+# freq_flags are an array of length-2 arrays of floats in units of Hz (freq ranges, inclusive)
+freq_flags: [[0, 110e6], 
+             [150e6, 155e6],
+             [190e6, 200e6]]
+
+# channel_flags are an array of ints or length-2 arrays of ints (channel ranges, inclusive)
+channel_flags: [0, 1, [10, 20], 60]
+
+
+# ---------------
+# TIME FLAGS
+# ---------------
+
+# # JD_flags are an array of length-2 arrays of floats in units of days (time ranges, inclusive)
+JD_flags: [[2458838.01, 2458838.03]]
+
+# LST_flags are an array of length-2 arrays of floats in units of hours (time ranges, inclusive).
+# If LST_1 > LST_2, it's assumed to span the 24 branch cut.
+LST_flags: [[2.3, 3.5],
+            [16.2, 18.4], 
+            [23.4, 0.1]]
+
+# integration_flags are an array of ints or length-2 arrays of ints (integration ranges, inclusive)
+integration_flags: [0, 1, [10, 20], 59]
+
+
+# ---------------
+# ANTENNA FLAGS
+# ---------------
+
+# ex_ants is an array of integer antennas or length-2 arrays of integer antennas and string antpols
+ex_ants: [0, 10, [1, Jee], [3, Jnn]]

--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -982,7 +982,7 @@ def read_a_priori_chan_flags(a_priori_flags_yaml, freqs=None):
     a_priori_flags_yaml : str
         Path to YAML file with a priori channel and/or frequency flags
     freqs : ndarray, optional
-        1D numpy array containing all frequencies in Hz, required in freq_flags is not empty in the YAML
+        1D numpy array containing all frequencies in Hz, required if freq_flags is not empty in the YAML
 
     Returns
     -------
@@ -1038,9 +1038,9 @@ def read_a_priori_int_flags(a_priori_flags_yaml, times=None, lsts=None):
     a_priori_flags_yaml : str
         Path to YAML file with a priori JD, LST, or integration flags
     times : ndarray, optional
-        1D numpy array containing all JDs in units of days, required in JD_flags is not empty in the YAML
+        1D numpy array containing all JDs in units of days, required if JD_flags is not empty in the YAML
     lsts : ndarray, optional
-        1D numpy array containing all lsts in units of hours, required in LST_flags is not empty in the YAML
+        1D numpy array containing all lsts in units of hours, required if LST_flags is not empty in the YAML
         
     Returns
     -------

--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -1057,7 +1057,7 @@ def read_a_priori_int_flags(a_priori_flags_yaml, times=None, lsts=None):
                 apif.append(intf)
             elif (type(intf) == list) and (len(intf) == 2) and (type(intf[0]) == type(intf[1]) == int):
                 if intf[0] > intf[1]:
-                    raise ValueError(f'Integration flag ranges must be increasing. {cf} is not.')
+                    raise ValueError(f'Integration flag ranges must be increasing. {intf} is not.')
                 apif += list(range(intf[0], intf[1] + 1))
             else:
                 raise TypeError(f'integration_flags entries must be integers or len-2 lists of integers. {intf} is not.')

--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -1114,13 +1114,15 @@ def read_a_priori_int_flags(a_priori_flags_yaml, times=None, lsts=None):
     return np.array(sorted(set(apif)))
 
 
-def read_a_priori_ant_flags(a_priori_flags_yaml, by_ant_pol=False, ant_pols=None):
+def read_a_priori_ant_flags(a_priori_flags_yaml, ant_indices_only=False, by_ant_pol=False, ant_pols=None):
     '''Parse an a priori flag YAML file for a priori antenna flags.
 
     Parameters
     ----------
     a_priori_flags_yaml : str
         Path to YAML file with a priori antenna flags
+    ant_indices_only : bool
+        If True, ignore polarizations and flag entire antennas when they appear, e.g. (1, 'Jee') --> 1.
     by_ant_pol : bool
         If True, expand all integer antenna indices into per-antpol entries using ant_pols 
     ant_pols : list of str
@@ -1132,6 +1134,9 @@ def read_a_priori_ant_flags(a_priori_flags_yaml, by_ant_pol=False, ant_pols=None
     a_priori_antenna_flags : list
          List of a priori antenna flags, either integers or ant-pol tuples e.g. (0, 'Jee')
     '''
+
+    if ant_indices_only and by_ant_pol:
+        raise ValueError("ant_indices_only and by_ant_pol can't both be True.")
     apaf = []
     apf = yaml.safe_load(open(a_priori_flags_yaml, 'r'))
 
@@ -1146,7 +1151,10 @@ def read_a_priori_ant_flags(a_priori_flags_yaml, by_ant_pol=False, ant_pols=None
                 # check that antpol string is valid if ant_pols is not empty
                 if (ant_pols is not None) and (ant[1] not in ant_pols):
                     raise ValueError(f'{ant[1]} is not a valid ant_pol in {ant_pols}.')
-                apaf += [tuple(ant)]
+                if ant_indices_only:
+                    apaf.append(ant[0])
+                else:
+                    apaf += [tuple(ant)]
             else:
                 raise TypeError(f'ex_ants entires must be integers or a list of one int and one str. {ant} is not.')
 

--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -11,6 +11,7 @@ import numpy as np
 import pickle as pkl
 import copy
 import re
+import yaml
 from collections import OrderedDict
 from .version import hera_qm_version_str
 from . import utils as qm_utils

--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -1014,8 +1014,8 @@ def read_a_priori_chan_flags(a_priori_flags_yaml, freqs=None):
 
         for ff in apf['freq_flags']:
             # validate each frequency pair
-            if (len(ff) != 2):
-                raise ValueError(f'freq_flags entires must be len-2 lists of floats. {ff} is not.')
+            if (type(ff) != list) or (len(ff) != 2):
+                raise TypeError(f'freq_flags entires must be len-2 lists of floats. {ff} is not.')
             try:
                 ff = [float(ff[0]), float(ff[1])]
             except ValueError:
@@ -1073,8 +1073,8 @@ def read_a_priori_int_flags(a_priori_flags_yaml, times=None, lsts=None):
         
         for tf in apf['JD_flags']:
             # validate time flag ranges
-            if (len(tf) != 2):
-                raise ValueError(f'JD_flags entires must be len-2 lists of floats. {tf} is not.')
+            if (type(tf) != list) or (len(tf) != 2):
+                raise TypeError(f'JD_flags entires must be len-2 lists of floats. {tf} is not.')
             try:
                 tf = [float(tf[0]), float(tf[1])]
             except ValueError:
@@ -1095,8 +1095,8 @@ def read_a_priori_int_flags(a_priori_flags_yaml, times=None, lsts=None):
 
         for lf in apf['LST_flags']:
             # validate LST flag ranges
-            if (len(lf) != 2):
-                raise ValueError(f'LST_flags entires must be len-2 lists of floats. {lf} is not.')
+            if (type(lf) != list) or (len(lf) != 2):
+                raise TypeError(f'LST_flags entires must be len-2 lists of floats. {lf} is not.')
             try:
                 lf = [float(lf[0]), float(lf[1])]
             except ValueError:

--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -999,7 +999,7 @@ def read_a_priori_chan_flags(a_priori_flags_yaml, freqs=None):
             if type(cf) == int:
                 apcf.append(cf)
             # add range of channel flags
-            elif (type(cf) == list) and (len(cf) == 2) and (type(cf[0]) == type(cf[1]) == int):
+            elif (type(cf) == list) and (len(cf) == 2) and isinstance(cf[0], int) and isinstance(cf[1], int):
                 if cf[0] > cf[1]:
                     raise ValueError(f'Channel flag ranges must be increasing. {cf} is not.')
                 apcf += list(range(cf[0], cf[1] + 1))
@@ -1055,7 +1055,7 @@ def read_a_priori_int_flags(a_priori_flags_yaml, times=None, lsts=None):
         for intf in apf['integration_flags']:
             if type(intf) == int:
                 apif.append(intf)
-            elif (type(intf) == list) and (len(intf) == 2) and (type(intf[0]) == type(intf[1]) == int):
+            elif (type(intf) == list) and (len(intf) == 2) and isinstance(intf[0], int) and isinstance(intf[1], int):
                 if intf[0] > intf[1]:
                     raise ValueError(f'Integration flag ranges must be increasing. {intf} is not.')
                 apif += list(range(intf[0], intf[1] + 1))
@@ -1105,9 +1105,9 @@ def read_a_priori_int_flags(a_priori_flags_yaml, times=None, lsts=None):
                 raise ValueError(f'Both entries in LST_flags must be between 0 and 24 hours. {lf} is not.')
 
             # add integration flag indices
-            if lf[0] <= lf[1]: # normal LST range
+            if lf[0] <= lf[1]:  # normal LST range
                 apif += list(np.argwhere((lsts >= lf[0]) & (lsts <= lf[1])).flatten())
-            else: # LST range that spans the 24-hour branch cut
+            else:  # LST range that spans the 24-hour branch cut
                 apif += list(np.argwhere((lsts >= lf[0]) | (lsts <= lf[1])).flatten())
              
     # Return unique frequency indices
@@ -1158,7 +1158,7 @@ def read_a_priori_ant_flags(a_priori_flags_yaml, by_ant_pol=False, ant_pols=None
             for ant in apaf:
                 if type(ant) == int:
                     apapf += [(ant, pol) for pol in ant_pols]
-                else: # then it's already and antpol tuple
+                else:  # then it's already and antpol tuple
                     apapf.append(ant)
             return sorted(set(apapf))
 

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -342,4 +342,12 @@ def test_ant_metrics_run_and_load_antenna_metrics():
     assert qmtest.recursive_compare_dicts(am.final_mod_z_scores, am_hdf5['final_mod_z_scores'])
     assert qmtest.recursive_compare_dicts(am.all_mod_z_scores, am_hdf5['all_mod_z_scores'])
 
+    # test a priori flagging via YAML
+    apf_yaml = os.path.join(DATA_PATH, 'a_priori_flags_old_pols.yaml')
+    ant_metrics.ant_metrics_run(four_pol_uvh5, overwrite=True, a_priori_xants_yaml=apf_yaml, verbose=True)
+    am_hdf5 = ant_metrics.load_antenna_metrics(four_pol_uvh5.replace('.uvh5', '.ant_metrics.hdf5'))
+    for ant in [(0, 'Jxx'), (0, 'Jyy'), (10, 'Jxx'), (10, 'Jyy'), (1, 'Jxx'), (3, 'Jyy')]:
+        assert ant in am_hdf5['xants']
+        assert am_hdf5['removal_iteration'][ant] == -1
+
     os.remove(four_pol_uvh5.replace('.uvh5', '.ant_metrics.hdf5'))

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -593,14 +593,14 @@ def test_read_a_priori_int_flags():
 
     # Test normal operation
     times = np.linspace(2458838.0, 2458838.1, 60)
-    lsts = np.linspace(5, 6, 60) # for this test, it doesn't matter if this doesn't match the above
+    lsts = np.linspace(5, 6, 60)  # for this test, it doesn't matter if this doesn't match the above
     apif = metrics_io.read_a_priori_int_flags(apf_yaml, times=times, lsts=lsts)
-    expected = np.array([0, 1, 6, 7, 8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 59])
+    expected = np.array([0, 1, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 59])
     np.testing.assert_array_equal(apif, expected)
 
     # Test normal operation with LST flags that span the 24-hour branch cut
     times = np.linspace(2458838.1, 2458838.2, 60)
-    lsts = np.linspace(22, 24, 60) # for this test, it doesn't matter if this doesn't match the above
+    lsts = np.linspace(22, 24, 60)  # for this test, it doesn't matter if this doesn't match the above
     apif = metrics_io.read_a_priori_int_flags(apf_yaml, times=times, lsts=lsts)
     expected = np.array([0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 42, 43, 44,
                         45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59])

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -685,7 +685,7 @@ def test_read_a_priori_ant_flags():
     with pytest.raises(ValueError):
         metrics_io.read_a_priori_ant_flags(apf_yaml, ant_pols=['Jxx'])
         
-    # Test error: malformated ex_ants
+    # Test error: malformatted ex_ants
     for ex_ants in [['Jee'], [[0, 1, 2]], [1.0]]:
         out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
         yaml.dump({'ex_ants': ex_ants}, open(out_yaml, 'w'))

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -573,7 +573,7 @@ def test_read_a_priori_chan_flags():
         metrics_io.read_a_priori_chan_flags(apf_yaml)
 
     # Test error: malformatted freq_flags
-    for freq_flags in [['Jee'], [[0, 1, 2]], [1.0], ['Jee', 'Jnn']]:
+    for freq_flags in [['Jee'], [[0, 1, 2]], [1.0], [['Jee', 'Jnn']]]:
         out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
         yaml.dump({'freq_flags': freq_flags}, open(out_yaml, 'w'))
         with pytest.raises(TypeError):
@@ -614,7 +614,7 @@ def test_read_a_priori_int_flags():
     os.remove(out_yaml)
     
     # Test error: malformatted integration_flags:
-    for integration_flags in [['Jee'], [[0, 1, 2]], [1.0], ['Jee', 'Jnn']]:
+    for integration_flags in [['Jee'], [[0, 1, 2]], [1.0], [['Jee', 'Jnn']]]:
         out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
         yaml.dump({'integration_flags': integration_flags}, open(out_yaml, 'w'))
         with pytest.raises(TypeError):
@@ -649,7 +649,7 @@ def test_read_a_priori_int_flags():
         metrics_io.read_a_priori_int_flags(apf_yaml, times=times)
 
     # Test error: malformatted LST_flags  
-    for LST_flags in [['Jee'], [[0, 1, 2]], [1.0], ['Jee', 'Jnn']]:
+    for LST_flags in [['Jee'], [[0, 1, 2]], [1.0], [['Jee', 'Jnn']]]:
         out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
         yaml.dump({'LST_flags': LST_flags}, open(out_yaml, 'w'))
         with pytest.raises(TypeError):
@@ -658,7 +658,7 @@ def test_read_a_priori_int_flags():
     
     # Test error: LST_flags out of range
     out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
-    yaml.dump({'LST_flags': [[0, 100]]}, open(out_yaml, 'w'))
+    yaml.dump({'LST_flags': [[[0, 100]]]}, open(out_yaml, 'w'))
     with pytest.raises(ValueError):
         metrics_io.read_a_priori_int_flags(out_yaml, lsts=lsts)
     os.remove(out_yaml)

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -658,7 +658,7 @@ def test_read_a_priori_int_flags():
     
     # Test error: LST_flags out of range
     out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
-    yaml.dump({'LST_flags': [[[0, 100]]]}, open(out_yaml, 'w'))
+    yaml.dump({'LST_flags': [[0, 100]]}, open(out_yaml, 'w'))
     with pytest.raises(ValueError):
         metrics_io.read_a_priori_int_flags(out_yaml, lsts=lsts)
     os.remove(out_yaml)

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -543,6 +543,50 @@ def test_boolean_read_write_hdf5():
     os.remove(test_file)
 
 
+def test_read_a_priori_chan_flags():
+    apf_yaml = os.path.join(DATA_PATH, 'a_priori_flags_sample.yaml')
+
+    # Test normal operation
+    freqs = np.linspace(100e6, 200e6, 64)
+    apcf = metrics_io.read_a_priori_chan_flags(apf_yaml, freqs=freqs)
+    expected = np.array([0, 1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14, 15, 16, 17, 
+                         18, 19, 20, 32, 33, 34, 57, 58, 59, 60, 61, 62, 63])
+    np.testing.assert_array_equal(apcf, expected)
+            
+    # Test error: channel ranges out of order
+    out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
+    yaml.dump({'channel_flags': [[10, 5]]}, open(out_yaml, 'w'))
+    with pytest.raises(ValueError):
+        metrics_io.read_a_priori_chan_flags(out_yaml)
+    os.remove(out_yaml)
+    
+    # Test error: malformatted channel_flags
+    for channel_flags in [['Jee'], [[0, 1, 2]], [1.0]]:
+        out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
+        yaml.dump({'channel_flags': channel_flags}, open(out_yaml, 'w'))
+        with pytest.raises(TypeError):
+            metrics_io.read_a_priori_chan_flags(out_yaml)
+        os.remove(out_yaml)
+
+    # Test error: missing freqs
+    with pytest.raises(ValueError):
+        metrics_io.read_a_priori_chan_flags(apf_yaml)
+
+    # Test error: malformatted freq_flags
+    for freq_flags in [['Jee'], [[0, 1, 2]], [1.0], ['Jee', 'Jnn']]:
+        out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
+        yaml.dump({'freq_flags': freq_flags}, open(out_yaml, 'w'))
+        with pytest.raises(TypeError):
+            metrics_io.read_a_priori_chan_flags(out_yaml, freqs=freqs)
+        os.remove(out_yaml)
+    
+    # Test error: freq ranges out of order
+    out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
+    yaml.dump({'freq_flags': [[200e6, 100e6]]}, open(out_yaml, 'w'))
+    with pytest.raises(ValueError):
+        metrics_io.read_a_priori_chan_flags(out_yaml, freqs=freqs)
+    os.remove(out_yaml)
+
 def test_read_a_priori_ant_flags():
     apf_yaml = os.path.join(DATA_PATH, 'a_priori_flags_sample.yaml')
 

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -678,10 +678,19 @@ def test_read_a_priori_ant_flags():
     expected = [0, (1, 'Jee'), 10, (3, 'Jnn')]
     assert set(expected) == set(apaf)
 
+    # Test operation in ant_indices_only mode
+    apaf = metrics_io.read_a_priori_ant_flags(apf_yaml, ant_indices_only=True)
+    expected = [0, 1, 10, 3]
+    assert set(expected) == set(apaf)
+
     # Test operation in by_ant_pol mode
     apaf = metrics_io.read_a_priori_ant_flags(apf_yaml, by_ant_pol=True, ant_pols=['Jee', 'Jnn'])
     expected = [(0, 'Jee'), (0, 'Jnn'), (1, 'Jee'), (3, 'Jnn'), (10, 'Jee'), (10, 'Jnn')]
     assert set(expected) == set(apaf)
+
+    # Test error: inconsistent options
+    with pytest.raises(ValueError):
+        metrics_io.read_a_priori_ant_flags(apf_yaml, ant_indices_only=True, by_ant_pol=True)
 
     # Test error: missing ant_pols
     with pytest.raises(ValueError):

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -630,7 +630,7 @@ def test_read_a_priori_int_flags():
         metrics_io.read_a_priori_int_flags(apf_yaml, lsts=lsts)
 
     # Test error: malformatted JD_flags
-    for JD_flags in [['Jee'], [[0, 1, 2]], [1.0], ['Jee', 'Jnn']]:
+    for JD_flags in [['Jee'], [[0, 1, 2]], [1.0], [['Jee', 'Jnn']]]:
         out_yaml = os.path.join(DATA_PATH, 'test_output', 'erroring.yaml')
         yaml.dump({'JD_flags': JD_flags}, open(out_yaml, 'w'))
         with pytest.raises(TypeError):
@@ -647,6 +647,12 @@ def test_read_a_priori_int_flags():
     # Test error: missing lsts
     with pytest.raises(ValueError):
         metrics_io.read_a_priori_int_flags(apf_yaml, times=times)
+
+    # Test error: lsts out or range
+    with pytest.raises(ValueError):
+        metrics_io.read_a_priori_int_flags(apf_yaml, times=times, lsts=np.linspace(23, 25, 60))
+    with pytest.raises(ValueError):
+        metrics_io.read_a_priori_int_flags(apf_yaml, times=times, lsts=np.linspace(-1, 1, 60))
 
     # Test error: malformatted LST_flags  
     for LST_flags in [['Jee'], [[0, 1, 2]], [1.0], [['Jee', 'Jnn']]]:

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -1042,7 +1042,7 @@ def test_xrfi_run(tmpdir):
 
     # check warnings
     with pytest.warns(None) as record:
-        xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, 'Just a test', kt_size=3)
+        xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, history='Just a test', kt_size=3)
     assert len(record) >= len(messages)
     n_matched_warnings = 0
     for i in range(len(record)):
@@ -1364,7 +1364,7 @@ def test_xrfi_run_edgeflag(tmpdir):
     shutil.copyfile(test_uvh5_file, model_file)
     # check warnings
     with pytest.warns(None) as record:
-        xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, 'Just a test', kt_size=2)
+        xrfi.xrfi_run(ocal_file, acal_file, model_file, raw_dfile, history='Just a test', kt_size=2)
     assert len(record) >= len(messages)
     n_matched_warnings = 0
     for i in range(len(record)):
@@ -1456,7 +1456,7 @@ def test_xrfi_run_edgeflag(tmpdir):
         shutil.copyfile(uvf, model_file)
         model_files.append(model_file)
     with pytest.warns(None) as record:
-        xrfi.xrfi_run(ocal_files, acal_files, model_files, raw_dfiles, 'Just a test', kt_size=1)
+        xrfi.xrfi_run(ocal_files, acal_files, model_files, raw_dfiles, history='Just a test', kt_size=1)
     assert len(record) >= len(messages)
     n_matched_warnings = 0
     for i in range(len(record)):
@@ -1506,7 +1506,7 @@ def test_xrfi_run_multifile(tmpdir):
     # check warnings
     with pytest.warns(None) as record:
         xrfi.xrfi_run(ocal_files, acal_files, model_files, raw_dfiles,
-                      'Just a test', kt_size=3, cross_median_filter=True)
+                      history='Just a test', kt_size=3, cross_median_filter=True)
     assert len(record) >= len(messages)
     n_matched_warnings = 0
     for i in range(len(record)):
@@ -1573,7 +1573,7 @@ def test_xrfi_run_multifile(tmpdir):
     # check warnings
     with pytest.warns(None) as record:
         xrfi.xrfi_run(ocal_files, acal_files, model_files, raw_dfiles,
-                      'Just a test', kt_size=3, cross_median_filter=True,
+                      history='Just a test', kt_size=3, cross_median_filter=True,
                       throw_away_edges=False, clobber=True)
     assert len(record) >= len(messages)
     n_matched_warnings = 0
@@ -1654,7 +1654,7 @@ def test_day_threshold_run(tmpdir):
             n_matched_warnings += 1
     assert n_matched_warnings == 8
 
-    xrfi.day_threshold_run(data_files, 'just a test')
+    xrfi.day_threshold_run(data_files, history='just a test')
     types = ['og', 'ox', 'ag', 'ax', 'v', 'cross', 'auto', 'omnical_chi_sq_renormed',
              'abscal_chi_sq_renormed', 'combined', 'total']
     for type in types:
@@ -1686,7 +1686,7 @@ def test_day_threshold_run_data_only(tmpdir):
     data_files = [raw_dfile]
     model_file = os.path.join(tmp_path, fake_obses[0] + '.omni_vis.uvh5')
     shutil.copyfile(test_uvh5_file, model_file)
-    xrfi.xrfi_run(None, None, None, raw_dfile, 'Just a test', kt_size=3, throw_away_edges=False)
+    xrfi.xrfi_run(None, None, None, raw_dfile, history='Just a test', kt_size=3, throw_away_edges=False)
     # Need to adjust time arrays when duplicating files
     uvd = UVData()
     uvd.read_uvh5(data_files[0])
@@ -1706,9 +1706,9 @@ def test_day_threshold_run_data_only(tmpdir):
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
     uvc.write_calfits(acal_file)
     # only perform median filter on autocorrs to hit lines where only first round exists.
-    xrfi.xrfi_run(None, None, None, data_files[1], 'Just a test', kt_size=3, auto_mean_filter=False, throw_away_edges=False)
+    xrfi.xrfi_run(None, None, None, data_files[1], history='Just a test', kt_size=3, auto_mean_filter=False, throw_away_edges=False)
 
-    xrfi.day_threshold_run(data_files, 'just a test')
+    xrfi.day_threshold_run(data_files, history='just a test')
     types = ['cross', 'auto', 'combined', 'total']
     for t in types:
         basename = '.'.join(fake_obses[0].split('.')[0:-2]) + '.' + t + '_threshold_flags.h5'
@@ -1740,7 +1740,7 @@ def test_day_threshold_run_cal_only(tmpdir):
     model_file = os.path.join(tmp_path, fake_obses[0] + '.omni_vis.uvh5')
     shutil.copyfile(test_uvh5_file, model_file)
     uvtest.checkWarnings(xrfi.xrfi_run, [acal_file, ocal_file, None,
-                                         None, 'Just a test'], {'kt_size': 3, 'output_prefixes': raw_dfile, 'throw_away_edges':False},
+                                         None], {'history': 'Just a test', 'kt_size': 3, 'output_prefixes': raw_dfile, 'throw_away_edges':False},
                          nwarnings=len(messages), message=messages, category=categories)
     # Need to adjust time arrays when duplicating files
     uvd = UVData()
@@ -1761,10 +1761,10 @@ def test_day_threshold_run_cal_only(tmpdir):
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
     uvc.write_calfits(acal_file)
     uvtest.checkWarnings(xrfi.xrfi_run, [acal_file, ocal_file, None,
-                                         None, 'Just a test'], {'kt_size': 3, 'output_prefixes': data_files[1], 'throw_away_edges':False},
+                                         None], {'history': 'Just a test', 'kt_size': 3, 'output_prefixes': data_files[1], 'throw_away_edges':False},
                          nwarnings=len(messages), message=messages, category=categories)
 
-    xrfi.day_threshold_run(data_files, 'just a test')
+    xrfi.day_threshold_run(data_files, history='just a test')
     types = ['ox', 'og', 'ax', 'ag', 'omnical_chi_sq_renormed', 'abscal_chi_sq_renormed',
              'combined', 'total']
     for t in types:
@@ -1796,7 +1796,7 @@ def test_day_threshold_run_omnivis_only(tmpdir):
     data_files = [raw_dfile]
     model_file = os.path.join(tmp_path, fake_obses[0] + '.omni_vis.uvh5')
     shutil.copyfile(test_uvh5_file, model_file)
-    xrfi.xrfi_run(None, None, model_file, None, 'Just a test', kt_size=3, output_prefixes=raw_dfile, throw_away_edges=False)
+    xrfi.xrfi_run(None, None, model_file, None, history='Just a test', kt_size=3, output_prefixes=raw_dfile, throw_away_edges=False)
     # Need to adjust time arrays when duplicating files
     uvd = UVData()
     uvd.read_uvh5(data_files[0])
@@ -1816,7 +1816,7 @@ def test_day_threshold_run_omnivis_only(tmpdir):
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
     uvc.write_calfits(acal_file)
     xrfi.xrfi_run(None, None, model_file, None, history='Just a test', kt_size=3, output_prefixes=data_files[1], throw_away_edges=False)
-    xrfi.day_threshold_run(data_files, 'just a test')
+    xrfi.day_threshold_run(data_files, history='just a test')
     types = ['v', 'combined']
     for t in types:
         basename = '.'.join(fake_obses[0].split('.')[0:-2]) + '.' + t + '_threshold_flags.h5'
@@ -1865,7 +1865,7 @@ def test_xrfi_h1c_run_filename_not_string():
     uvd = UVData()
     uvd.read_miriad(test_d_file)
     pytest.raises(ValueError, xrfi.xrfi_h1c_run, uvd,
-                  'Just a test.', filename=5)
+                  history='Just a test.', filename=5)
 
 
 def test_xrfi_h1c_run_uvfits_no_xrfi_path():
@@ -1944,7 +1944,7 @@ def test_xrfi_h1c_run_incorrect_model():
     uvd = UVData()
     uvd.read_miriad(test_d_file)
     bad_uvfits_test = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA.uvfits')
-    pytest.raises(ValueError, xrfi.xrfi_h1c_run, uvd, 'Just a test.',
+    pytest.raises(ValueError, xrfi.xrfi_h1c_run, uvd, history='Just a test.',
                   filename=test_d_file, model_file=bad_uvfits_test,
                   model_file_format='uvfits', xrfi_path=xrfi_path, kt_size=3)
 
@@ -1974,13 +1974,13 @@ def test_xrfi_h1c_run_incorrect_calfits():
     uvd = UVData()
     uvd.read_miriad(test_d_file)
     bad_calfits = os.path.join(DATA_PATH, 'zen.2457555.42443.HH.uvcA.omni.calfits')
-    pytest.raises(ValueError, xrfi.xrfi_h1c_run, uvd, 'Just a test.',
+    pytest.raises(ValueError, xrfi.xrfi_h1c_run, uvd, history='Just a test.',
                   filename=test_d_file, calfits_file=bad_calfits,
                   xrfi_path=xrfi_path, kt_size=3)
 
 
 def test_xrfi_h1c_run_indata_string_filename_not_string():
-    pytest.raises(ValueError, xrfi.xrfi_h1c_run, 'foo', 'Just a test.',
+    pytest.raises(ValueError, xrfi.xrfi_h1c_run, 'foo', history='Just a test.',
                   filename=3)
 
 

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -260,6 +260,9 @@ def get_metrics_ArgumentParser(method_name):
         ap.add_argument('--data_file', default=None, type=str, help='Raw visibility '
                         'data files to flag on.',
                         nargs='+')
+        ap.add_argument('--a_priori_flag_yaml', default=None, type=str,
+                        help=('Path to a priori flagging YAML with frequency, time, and/or '
+                              'antenna flagsfor parsable by hera_qm.metrics_io.read_a_priori_*_flags()'))
         ap.add_argument('--xrfi_path', default='', type=str,
                         help='Path to save flag files to. Default is same directory as input file.')
         ap.add_argument('--kt_size', default=8, type=int,
@@ -289,6 +292,9 @@ def get_metrics_ArgumentParser(method_name):
         ap.prog = 'xrfi_run_data_only.py'
         ap.add_argument('--data_files', default=None, type=str, help='Raw visibility '
                         'data files to flag on.', nargs='+')
+        ap.add_argument('--a_priori_flag_yaml', default=None, type=str,
+                        help=('Path to a priori flagging YAML with frequency, time, and/or '
+                              'antenna flagsfor parsable by hera_qm.metrics_io.read_a_priori_*_flags()'))        
         ap.add_argument('--xrfi_path', default='', type=str,
                         help='Path to save flag files to. Default is same directory as input file.')
         ap.add_argument('--kt_size', default=8, type=int,

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -51,6 +51,9 @@ def get_metrics_ArgumentParser(method_name):
                         help='4-pol visibility files used to compute antenna metrics')
         ap.add_argument('--apriori_xants', type=int, nargs='*', default=[],
                         help='space-delimited list of integer antenna numbers to exclude apriori.')
+        ap.add_argument('--a_priori_xants_yaml', type=str, default=None,
+                        help=('path to a priori flagging YAML with xant information parsable by '
+                              'hera_qm.metrics_io.read_a_priori_ant_flags()'))
         ap.add_argument('--crossCut', default=5.0, type=float,
                         help='Modified z-score cut for most cross-polarized antenna. Default 5 "sigmas"')
         ap.add_argument('--deadCut', default=5.0, type=float,

--- a/scripts/ant_metrics_run.py
+++ b/scripts/ant_metrics_run.py
@@ -12,6 +12,7 @@ args = ap.parse_args()
 history = ' '.join(sys.argv)
 ant_metrics.ant_metrics_run(args.data_files,
                             apriori_xants=args.apriori_xants,
+                            a_priori_xants_yaml=args.a_priori_xants_yaml,
                             crossCut=args.crossCut,
                             deadCut=args.deadCut,
                             run_cross_pols=args.run_cross_pols,

--- a/scripts/xrfi_run.py
+++ b/scripts/xrfi_run.py
@@ -11,7 +11,8 @@ ap = utils.get_metrics_ArgumentParser('xrfi_run')
 args = ap.parse_args()
 history = ' '.join(sys.argv)
 
-xrfi.xrfi_run(args.ocalfits_files, args.acalfits_files, args.model_files, args.data_files,
+xrfi.xrfi_run(args.ocalfits_files, args.acalfits_files, args.model_files,
+              args.data_files, a_priori_flag_yaml=args.a_priori_flag_yaml,
               history, xrfi_path=args.xrfi_path, throw_away_edges=not(args.keep_edge_times),
               kt_size=args.kt_size, kf_size=args.kf_size, sig_init=args.sig_init,
               sig_adj=args.sig_adj, ex_ants=args.ex_ants,

--- a/scripts/xrfi_run.py
+++ b/scripts/xrfi_run.py
@@ -13,7 +13,7 @@ history = ' '.join(sys.argv)
 
 xrfi.xrfi_run(args.ocalfits_files, args.acalfits_files, args.model_files,
               args.data_files, a_priori_flag_yaml=args.a_priori_flag_yaml,
-              history, xrfi_path=args.xrfi_path, throw_away_edges=not(args.keep_edge_times),
+              history=history, xrfi_path=args.xrfi_path, throw_away_edges=not(args.keep_edge_times),
               kt_size=args.kt_size, kf_size=args.kf_size, sig_init=args.sig_init,
               sig_adj=args.sig_adj, ex_ants=args.ex_ants,
               Nwf_per_load=args.Nwf_per_load,

--- a/scripts/xrfi_run_data_only.py
+++ b/scripts/xrfi_run_data_only.py
@@ -11,7 +11,7 @@ ap = utils.get_metrics_ArgumentParser('xrfi_run_data_only')
 args = ap.parse_args()
 history = ' '.join(sys.argv)
 
-xrfi.xrfi_run(data_files=args.data_files,
+xrfi.xrfi_run(data_files=args.data_files, a_priori_flag_yaml=args.a_priori_flag_yaml,
               cross_median_filter=args.cross_median_filter,
               cross_mean_filter=not(args.skip_cross_mean_filter),
               history=history, xrfi_path=args.xrfi_path, throw_away_edges=not(args.keep_edge_times),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_args = {
                 'scripts/xrfi_h3c_idr2_1_run.py',
                 'scripts/xrfi_h3ca_rtp_run.py',
                 'scripts/xrfi_run_data_only.py'
-               ],
+                ],
     'version': version.version,
     'package_data': {'hera_qm': data_files},
     'setup_requires': ['pytest-runner'],


### PR DESCRIPTION
This PR builds a more systematic way to carry around human-readable a priori flags for antennas, channels, frequencies, integrations, JDs, and LSTs. 

This should enable us to handle #332 via #358 (or a replacement PR if @anguta finds it easier to start over).

This PR implements antenna flagging in ant_metrics and unit tests it. It also enables antenna flagging in XRFI via YAML without tests yet since it will be easier to test when when frequency (and maybe time???) flags are added to XRFI via the YAML.