### PR TITLE
fix bug where abscal switches are being skipped.

### DIFF
--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1961,6 +1961,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     uvmetrics = ['uvf_ag', 'uvf_ax', 'uvf_az']
     uvflags = ['uvf_agf', 'uvf_axf', 'uvf_azf']
     input_uvs = ['uvc_a', 'uvc_a', 'uvc_a']
+    filter_switches = [abscal_median_filter, abscal_chi2_mean_filter, abscal_zscore_filter]
     # iterate through abscal median filters.
     for mf, ff, switch, alg, label, mode, input, api in zip(uvmetrics, uvflags, filter_switches, cal_algs, labels, modes, input_uvs, apply_inits):
             vdict['uvc_a'], vdict[mf], vdict[ff], vdict['uvf_apriori'], metrics, flags = xrfi_run_step(uv=vdict[input], uv_files=inputs_dict['acalfits_files'], alg=alg, kt_size=kt_size, kf_size=kf_size,
@@ -2065,6 +2066,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     uvmetrics = ['uvf_ag2', 'uvf_ax2', 'uvf_az2']
     uvflags = ['uvf_agf2', 'uvf_axf2', 'uvf_azf2']
     input_uvs = ['uvc_a', 'uvc_a', 'uvc_a']
+    filter_switches = [abscal_median_filter, abscal_chi2_mean_filter, abscal_zscore_filter]
     for mf, ff, switch, alg, label, mode, input, api in zip(uvmetrics, uvflags, filter_switches, cal_algs, labels, modes, input_uvs, apply_inits):
             vdict['uvc_a'], vdict[mf], vdict[ff], _, metrics, flags = xrfi_run_step(uv=vdict[input], alg=alg, kt_size=kt_size, kf_size=kf_size, reinitialize=False,
                                                                                     xants=xants, cal_mode=mode, sig_init=sig_init, sig_adj=sig_adj, wf_method=wf_method,


### PR DESCRIPTION
a line was left out (only for abscal annoyingly) that reassigns the list of switches that tell `xrfi_run_step` whether to run or skip filters. 