### PR TITLE
Fix issues related to new UVCal metadata and warnings

### DIFF
--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -11,6 +11,9 @@ from hera_qm import metrics_io
 from hera_qm.data import DATA_PATH
 import hera_qm.tests as qmtest
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The uvw_array does not match the expected values given the antenna positions.",
+)
 
 def test_per_antenna_modified_z_scores():
     metric = {(0, 'Jnn'): 1, (50, 'Jnn'): 0, (2, 'Jnn'): 2,

--- a/hera_qm/tests/test_firstcal_metrics.py
+++ b/hera_qm/tests/test_firstcal_metrics.py
@@ -15,6 +15,10 @@ from hera_qm import metrics_io
 import sys
 import pytest
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:telescope_location is not set. Using known values for HERA.",
+    "ignore:antenna_positions is not set. Using known values for HERA."
+)
 
 @pytest.fixture(scope='function')
 def firstcal_setup():

--- a/hera_qm/tests/test_omnical_metrics.py
+++ b/hera_qm/tests/test_omnical_metrics.py
@@ -11,6 +11,10 @@ from collections import OrderedDict
 import pytest
 import numpy as np
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:telescope_location is not set. Using known values for HERA.",
+    "ignore:antenna_positions is not set. Using known values for HERA."
+)
 
 @pytest.fixture(scope='function')
 def omnical_data():

--- a/hera_qm/tests/test_utils.py
+++ b/hera_qm/tests/test_utils.py
@@ -16,6 +16,12 @@ from pyuvdata import UVData
 from pyuvdata import UVCal
 import pyuvdata.utils as uvutils
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The uvw_array does not match the expected values given the antenna positions.",
+    "ignore:telescope_location is not set. Using known values for HERA.",
+    "ignore:antenna_positions is not set. Using known values for HERA."
+)
+
 def test_get_metrics_ArgumentParser_ant_metrics():
     a = utils.get_metrics_ArgumentParser('ant_metrics')
     # First try defaults - test a few of them
@@ -350,7 +356,10 @@ def test_apply_yaml_flags(tmpdir):
     pytest.raises(NotImplementedError, utils.apply_yaml_flags, 'uvdata', test_flag_jds)
     # check that not providing lat_lon_alt_degrees and a telescope location that is not in the pyuvdata.KNOWN_TELESCOPES dict
     # throws a NotImplementedError
-    pytest.raises(NotImplementedError, utils.apply_yaml_flags, uvc, test_flag_jds, None, 'MITEOR')
+    # must remove the `lst_array` from the cal object first to test this
+    uvc2 = uvc.copy()
+    uvc2.lst_array = None
+    pytest.raises(NotImplementedError, utils.apply_yaml_flags, uvc2, test_flag_jds, None, 'MITEOR')
     # check that more then a single spw throws a NotImplementedError
     uvc.Nspws = 2
     pytest.raises(NotImplementedError, utils.apply_yaml_flags, uvc, test_flag_jds)

--- a/hera_qm/tests/test_vis_metrics.py
+++ b/hera_qm/tests/test_vis_metrics.py
@@ -12,6 +12,9 @@ import copy
 import pytest
 from scipy import stats
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The uvw_array does not match the expected values given the antenna positions.",
+)
 
 @pytest.fixture(scope='function')
 def vismetrics_data():

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -689,7 +689,7 @@ def apply_yaml_flags(uv, a_priori_flag_yaml, lat_lon_alt_degrees=None, telescope
         raise NotImplementedError("apply_yaml_flags does not support multiple spws at this time.")
     # if UVCal provided, get lst_array from times.
     # If lat_lon_alt is not specified, try to infer it from the telescope name, which calfits files generally carry around
-    if not hasattr(uv, 'lst_array'):
+    if uv.lst_array is None:
         if lat_lon_alt_degrees is None:
             if telescope_name is None:
                 telescope_name = uv.telescope_name

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -687,7 +687,7 @@ def apply_yaml_flags(uv, a_priori_flag_yaml, lat_lon_alt_degrees=None, telescope
     # only support single spw right now.
     if issubclass(uv.__class__, (UVData, UVCal)) and uv.Nspws > 1:
         raise NotImplementedError("apply_yaml_flags does not support multiple spws at this time.")
-    # if UVCal provided, get lst_array from times.
+    # if UVCal provided and lst_array is None, get lst_array from times.
     # If lat_lon_alt is not specified, try to infer it from the telescope name, which calfits files generally carry around
     if uv.lst_array is None:
         if lat_lon_alt_degrees is None:


### PR DESCRIPTION
UVCal was just updated to include new metadata and a few warnings associated with that were added. This update broke one line of code in `utils` that assumed that the `lst_array` was either not an attribute or required, which is not always true for UVCal (it is currently optional but will become required in a future version of pyuvdata). It also broke some tests because new warnings were being issued.

I added some pytest warning filters to filter a bunch of pyuvdata warnings that I do not think are too important for hera_qm, but someone with more hera_qm knowledge should check that.