### PR TITLE
Fix definition of modified z-score in auto_metrics

### DIFF
--- a/ci/hera_qm_tests.yml
+++ b/ci/hera_qm_tests.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - numpy=1.19 # TODO UPDATE
+  - numpy>=1.10
   - pip
   - astropy>=3.2.3
   - h5py

--- a/ci/hera_qm_tests.yml
+++ b/ci/hera_qm_tests.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - astropy>=3.2.3
   - h5py
+  - pyuvdata
   - scipy
   - pytest
   - scikit-learn # from hera_cal
@@ -14,6 +15,5 @@ dependencies:
   - matplotlib
   - coveralls
   - pip:
-    - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
     - git+https://github.com/HERA-Team/uvtools
     - git+https://github.com/HERA-Team/hera_cal

--- a/ci/hera_qm_tests.yml
+++ b/ci/hera_qm_tests.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - numpy>=1.10
+  - numpy=1.19 # TODO UPDATE
   - pip
   - astropy>=3.2.3
   - h5py

--- a/ci/hera_qm_tests.yml
+++ b/ci/hera_qm_tests.yml
@@ -7,7 +7,6 @@ dependencies:
   - pip
   - astropy>=3.2.3
   - h5py
-  - pyuvdata
   - scipy
   - pytest
   - scikit-learn # from hera_cal
@@ -15,5 +14,6 @@ dependencies:
   - matplotlib
   - coveralls
   - pip:
+    - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
     - git+https://github.com/HERA-Team/uvtools
     - git+https://github.com/HERA-Team/hera_cal

--- a/hera_qm/auto_metrics.py
+++ b/hera_qm/auto_metrics.py
@@ -202,7 +202,7 @@ def iterative_spectrum_modz(auto_spectra, prior_ex_ants=[], modz_cut=5.0, cut_on
     return ex_ants, modzs
 
 
-def auto_metrics_run(metric_outfile, raw_auto_files, median_round_modz_cut=16., mean_round_modz_cut=8.,
+def auto_metrics_run(metric_outfile, raw_auto_files, median_round_modz_cut=8., mean_round_modz_cut=4.,
                      edge_cut=100, Kt=8, Kf=8, sig_init=5.0, sig_adj=2.0, chan_thresh_frac=.05, 
                      history='', overwrite=False):
     '''Evaluates day-long autocorrelation waterfalls for "outlierness" in shape, power, temporal 

--- a/hera_qm/auto_metrics.py
+++ b/hera_qm/auto_metrics.py
@@ -143,7 +143,7 @@ def spectrum_modz_scores(auto_spectra, ex_ants=[], overall_spec_func=np.nanmedia
     median_diff_metric = np.median([metric for bl, metric in diff_metrics.items() if bl[0] not in ex_ants])
     mad_diff_metric = np.median([np.abs(metric - median_diff_metric) for bl, metric in diff_metrics.items() 
                                  if bl[0] not in ex_ants])
-    modzs = {bl: 1.4826 * (diff_metrics[bl] - median_diff_metric) / mad_diff_metric for bl in auto_spectra}
+    modzs = {bl: (diff_metrics[bl] - median_diff_metric) / mad_diff_metric / 1.4826 for bl in auto_spectra}
     return modzs
 
 

--- a/hera_qm/tests/test_auto_metrics.py
+++ b/hera_qm/tests/test_auto_metrics.py
@@ -116,9 +116,9 @@ def test_spectrum_modz_scores():
     modzs = auto_metrics.spectrum_modz_scores(auto_spectra, overall_spec_func=np.nanmean)
     for bl in auto_spectra:
         if bl == (0, 0, 'ee'):
-            assert modzs[bl] > 10000
+            assert modzs[bl] > 5000
         else:
-            assert np.abs(modzs[bl]) < 10
+            assert np.abs(modzs[bl]) < 5
             
     # test with a nan
     auto_spectra = {bl: .01 * np.random.randn(100) + 1 for bl in bls}
@@ -127,9 +127,9 @@ def test_spectrum_modz_scores():
     modzs = auto_metrics.spectrum_modz_scores(auto_spectra, overall_spec_func=np.nanmean)
     for bl in auto_spectra:
         if bl == (0, 0, 'ee'):
-            assert modzs[bl] > 10000
+            assert modzs[bl] > 5000
         else:
-            assert np.abs(modzs[bl]) < 10
+            assert np.abs(modzs[bl]) < 5
 
     # test with single spectral channel outlier in median mode
     auto_spectra = {bl: .01 * np.random.randn(100) + 1 for bl in bls}
@@ -144,9 +144,9 @@ def test_spectrum_modz_scores():
     modzs = auto_metrics.spectrum_modz_scores(auto_spectra, overall_spec_func=np.nanmean, metric_func=np.nanmean)
     for bl in auto_spectra:
         if bl == (0, 0, 'ee'):
-            assert modzs[bl] > 100
+            assert modzs[bl] > 50
         else:
-            assert np.abs(modzs[bl]) < 10
+            assert np.abs(modzs[bl]) < 5
 
     # test abs_diff=False
     auto_spectra = {bl: .01 * np.random.randn(100) + 1 for bl in bls}
@@ -154,9 +154,9 @@ def test_spectrum_modz_scores():
     modzs = auto_metrics.spectrum_modz_scores(auto_spectra, overall_spec_func=np.nanmean, abs_diff=False)
     for bl in auto_spectra:
         if bl == (0, 0, 'ee'):
-            assert modzs[bl] < -10000
+            assert modzs[bl] < -5000
         else:
-            assert np.abs(modzs[bl]) < 10
+            assert np.abs(modzs[bl]) < 5
 
     # test metric_log=True
     auto_spectra = {bl: .01 * np.random.randn(100) + 1 for bl in bls}
@@ -165,21 +165,21 @@ def test_spectrum_modz_scores():
     modzs = auto_metrics.spectrum_modz_scores(auto_spectra, overall_spec_func=np.nanmean, metric_log=True, ex_ants=[0, 1])
     for bl in auto_spectra:
         if bl == (0, 0, 'ee'):
-            assert modzs[bl] > 1000
+            assert modzs[bl] > 500
         elif bl == (1, 1, 'ee'):
-            assert modzs[bl] > 1000
+            assert modzs[bl] > 500
         else:
-            assert np.abs(modzs[bl]) < 10
+            assert np.abs(modzs[bl]) < 5
 
     # test both metric_log=True and abs_diff=False
     modzs = auto_metrics.spectrum_modz_scores(auto_spectra, overall_spec_func=np.nanmean, metric_log=True, abs_diff=False, ex_ants=[0, 1])
     for bl in auto_spectra:
         if bl == (0, 0, 'ee'):
-            assert modzs[bl] > 1000
+            assert modzs[bl] > 500
         elif bl == (1, 1, 'ee'):
-            assert modzs[bl] < -1000, modzs[bl]
+            assert modzs[bl] < -500, modzs[bl]
         else:
-            assert np.abs(modzs[bl]) < 10
+            assert np.abs(modzs[bl]) < 5
 
 
 def test_iterative_spectrum_modz():
@@ -216,7 +216,7 @@ def test_auto_metrics_run():
     auto_files = glob.glob(os.path.join(DATA_PATH, 'zen.2459122.*.sum.autos.downselected.uvh5'))
     metrics_outfile = os.path.join(DATA_PATH, 'unittest_auto_metrics.h5')
     ex_ants, modzs, spectra, flags = auto_metrics.auto_metrics_run(metrics_outfile, auto_files,
-                                                                   median_round_modz_cut=150., mean_round_modz_cut=10.,
+                                                                   median_round_modz_cut=75., mean_round_modz_cut=5.,
                                                                    edge_cut=100, Kt=8, Kf=8, sig_init=5.0, sig_adj=2.0, 
                                                                    chan_thresh_frac=.05, history='unittest', overwrite=True)
     metrics_in = metrics_io.load_metric_file(metrics_outfile)
@@ -265,8 +265,8 @@ def test_auto_metrics_run():
 
     # test saved parameters
     assert metrics_in['parameters']
-    assert metrics_in['parameters']['median_round_modz_cut'] == 150.
-    assert metrics_in['parameters']['mean_round_modz_cut'] == 10.
+    assert metrics_in['parameters']['median_round_modz_cut'] == 75.
+    assert metrics_in['parameters']['mean_round_modz_cut'] == 5.
     assert metrics_in['parameters']['edge_cut'] == 100
     assert metrics_in['parameters']['Kt'] == 8 
     assert metrics_in['parameters']['Kf'] == 8

--- a/hera_qm/tests/test_utils.py
+++ b/hera_qm/tests/test_utils.py
@@ -39,7 +39,7 @@ def test_get_metrics_ArgumentParser_auto_metrics():
     args = a.parse_args(['out.h5', 'auto1.uvh5', 'auto2.uvh5'])
     assert args.metric_outfile == 'out.h5'
     assert args.raw_auto_files == ['auto1.uvh5', 'auto2.uvh5']
-    assert args.median_round_modz_cut == 16.0
+    assert args.median_round_modz_cut == 8.0
     assert args.chan_thresh_frac == .05
     # try to set something
     args = a.parse_args(['out.h5', 'auto1.uvh5', 'auto2.uvh5', '--sig_init', '10.3'])

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -86,9 +86,9 @@ def get_metrics_ArgumentParser(method_name):
                         help='Path to save auto_metrics hdf5 file.')
         ap.add_argument('raw_auto_files', type=str, nargs='+', 
                         help='Paths to data files including autocorrelations.')
-        ap.add_argument('--median_round_modz_cut', default=16., type=float, 
+        ap.add_argument('--median_round_modz_cut', default=8., type=float, 
                         help='Round 1 (median-based) cut on antenna modified Z-score.')
-        ap.add_argument('--mean_round_modz_cut', default=8., type=float, 
+        ap.add_argument('--mean_round_modz_cut', default=4., type=float, 
                         help='Round 2 (mean-based) cut on antenna modified Z-score.')
         ap.add_argument('--edge_cut', default=100, type=int, 
                         help='Number of channels on either end to flag (i.e. ignore) when looking for antenna outliers.')


### PR DESCRIPTION
I was multiplying by 1.4826 instead of dividing by 1.4826. So all the modified z-scores in previous calculations were off by a factor of ~2. This fixes that bug and changes the defaults to reflect that change.