### PR TITLE
discard data associated with antennas flagged in yaml file.

### DIFF
--- a/hera_qm/tests/test_utils.py
+++ b/hera_qm/tests/test_utils.py
@@ -328,6 +328,24 @@ def test_apply_yaml_flags_uvdata(tmpdir, filein, flag_freqs, flag_times, flag_an
                 assert not np.all(uvd.flag_array[blt_selection][: , :, :, pol_selection])\
                 or np.count_nonzero(blt_selection) == 0 or np.count_nonzero(pol_selection) == 0
 
+        # test removing antennas from the data if we are not running no_ants:
+        if flag_ants:
+            all_ants = np.unique(np.hstack([uvd.ant_1_array, uvd.ant_2_array]))
+            uvd = utils.apply_yaml_flags(uvd, test_flag, flag_freqs=flag_freqs, flag_times=flag_times,
+                                        flag_ants=flag_ants, throw_away_flagged_ants=True, ant_indices_only=True)
+            trimmed_ants = np.unique(np.hstack([uvd.ant_1_array, uvd.ant_2_array]))
+            # make sure there was a flagged antenna in the original flagged antennas.
+            assert np.any([a in all_ants for a in [0, 10, 1, 3]])
+            for a in [0, 10, 1, 3]:
+                if a in all_ants:
+                    assert a not in trimmed_ants
+            # test NotImplementedError when trying to throw away flagged antennas when ant_indices_only is False
+            pytest.raises(NotImplementedError, utils.apply_yaml_flags, uv=uvd, a_priori_flag_yaml=test_flag,
+                         flag_freqs=flag_freqs, flag_times=flag_times,
+                         flag_ants=flag_ants, throw_away_flagged_ants=True, ant_indices_only=False)
+
+
+
 @pytest.mark.parametrize(
     "filein",
     ["a_priori_flags_integrations.yaml",
@@ -376,6 +394,19 @@ def test_apply_yaml_flags_uvcal(filein, new_metadata):
                 pol_selection = np.where(uvc.jones_array == pol_num)[0]
             ant_selection = uvc.ant_array == antnum
             assert np.all(uvc.flag_array[ant_selection][:, :, :, :, pol_selection])
+
+        # test removing antennas from the data:
+        all_ants = uvc.ant_array
+        uvc = utils.apply_yaml_flags(uvc, test_flag, throw_away_flagged_ants=True, ant_indices_only=True)
+        trimmed_ants = uvc.ant_array
+        # make sure there was a flagged antenna in the original flagged antennas.
+        assert np.any([a in all_ants for a in [0, 10, 1, 3]])
+        for a in [0, 10, 1, 3]:
+            if a in all_ants:
+                assert a not in trimmed_ants
+        # test NotImplementedError when trying to throw away flagged antennas when ant_indices_only is False
+        pytest.raises(NotImplementedError, utils.apply_yaml_flags, uvc, a_priori_flag_yaml=test_flag,
+                     throw_away_flagged_ants=True, ant_indices_only=False)
 
 def test_apply_yaml_flags_errors():
     test_flag_jds = os.path.join(DATA_PATH, 'a_priori_flags_jds.yaml')

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -82,25 +82,25 @@ def get_metrics_ArgumentParser(method_name):
 
     elif method_name == 'auto_metrics':
         ap.prog = 'auto_metrics.py'
-        ap.add_argument('metric_outfile', type=str, 
+        ap.add_argument('metric_outfile', type=str,
                         help='Path to save auto_metrics hdf5 file.')
-        ap.add_argument('raw_auto_files', type=str, nargs='+', 
+        ap.add_argument('raw_auto_files', type=str, nargs='+',
                         help='Paths to data files including autocorrelations.')
-        ap.add_argument('--median_round_modz_cut', default=8., type=float, 
+        ap.add_argument('--median_round_modz_cut', default=8., type=float,
                         help='Round 1 (median-based) cut on antenna modified Z-score.')
-        ap.add_argument('--mean_round_modz_cut', default=4., type=float, 
+        ap.add_argument('--mean_round_modz_cut', default=4., type=float,
                         help='Round 2 (mean-based) cut on antenna modified Z-score.')
-        ap.add_argument('--edge_cut', default=100, type=int, 
+        ap.add_argument('--edge_cut', default=100, type=int,
                         help='Number of channels on either end to flag (i.e. ignore) when looking for antenna outliers.')
         ap.add_argument('--Kt', default=8, type=int,
                         help='Time kernel half-width for RFI flagging.')
         ap.add_argument('--Kf', default=8, type=int,
                         help='Frequency kernel half-width for RFI flagging.')
-        ap.add_argument('--sig_init', default=5.0, type=float, 
+        ap.add_argument('--sig_init', default=5.0, type=float,
                         help='The number of sigmas above which to flag pixels.')
-        ap.add_argument('--sig_adj', default=2.0, type=float, 
+        ap.add_argument('--sig_adj', default=2.0, type=float,
                         help='The number of sigmas above which to flag pixels adjacent to flags.')
-        ap.add_argument('--chan_thresh_frac', default=.05, type=float, 
+        ap.add_argument('--chan_thresh_frac', default=.05, type=float,
                         help='The fraction of flagged times (ignoring completely flagged times) above which to flag a whole channel.')
         ap.add_argument("--clobber", default=False, action="store_true",
                         help='Overwrites existing metric_outfile (default False).')
@@ -677,7 +677,7 @@ def strip_extension(path, return_ext=False):
 
 def apply_yaml_flags(uv, a_priori_flag_yaml, lat_lon_alt_degrees=None, telescope_name=None,
                      ant_indices_only=False, by_ant_pol=False, ant_pols=None,
-                     flag_ants=True, flag_freqs=True, flag_times=True):
+                     flag_ants=True, flag_freqs=True, flag_times=True, throw_away_flagged_ants=False):
     """Apply frequency and time flags to a UVData or UVCal object
 
     This function takes in a uvdata or uvcal object and applies
@@ -714,6 +714,9 @@ def apply_yaml_flags(uv, a_priori_flag_yaml, lat_lon_alt_degrees=None, telescope
     flag_times : bool, optional
         specify whether or not to flag times
         default is True.
+    throw_away_flagged_ants : bool, optional
+        if True, remove flagged antennas from the data.
+        default is False.
     Returns
     -------
         uv : UVData or UVCal object
@@ -817,5 +820,15 @@ def apply_yaml_flags(uv, a_priori_flag_yaml, lat_lon_alt_degrees=None, telescope
                 if np.any(ant_selection):
                     for antind in np.where(ant_selection)[0]:
                         uv.flag_array[antind, :, :, :, pol_selection] =True
+        if throw_away_flagged_ants:
+            if ant_indices_only:
+                if issubclass(uv.__class__, UVCal) or (isinstance(uv, UVFlag) and uv.type == 'antenna'):
+                    antennas_to_keep = [a for a in uv.ant_array if a not in flagged_ants]
+                    uv.select(antenna_nums=antennas_to_keep)
+                elif issubclass(uv.__class__, UVData) or (isinstance(uv, UVFlag) and uv.type == 'baseline'):
+                    antennas_to_keep = [a for a in np.unique(np.hstack([uv.ant_1_array, uv.ant_2_array])) if a not in flagged_ants]
+                    uv.select(antenna_nums=antennas_to_keep)
+            else:
+                raise NotImplementedError("throwing away flagged antennas only implemented for ant_indices_only=True")
     # return uv with flags applied.
     return uv


### PR DESCRIPTION
New functionality in `apply_yaml_flags` to throw away data associated with flagged antennas to save us space and time.