### PR TITLE
Make fixes for numpy v1.20

### DIFF
--- a/hera_qm/metrics_io.py
+++ b/hera_qm/metrics_io.py
@@ -116,7 +116,7 @@ def _recursively_save_dict_to_group(h5file, path, in_dict):
         with h5py, a TypeError is raised.
 
     """
-    allowed_types = (np.ndarray, np.float32, np.float, np.int,
+    allowed_types = (np.ndarray, np.float32, float, int,
                      bytes, str, list, bool, np.bool_)
     compressable_types = (np.ndarray, list)
     for key in in_dict:
@@ -438,7 +438,7 @@ def _recursively_parse_json(in_dict):
         if key in known_string_keys:
             out_dict[out_key] = str(in_dict[key])
         elif key in bool_keys:
-            out_dict[out_key] = np.bool(in_dict[key])
+            out_dict[out_key] = np.bool_(in_dict[key])
         elif key in float_keys:
             out_dict[out_key] = float(in_dict[key])
         elif key in antpol_dict_keys:
@@ -473,8 +473,8 @@ def _recursively_parse_json(in_dict):
             elif isinstance(in_dict[key], (list, np.ndarray)):
                 try:
                     if len(in_dict[key]) > 0:
-                        if isinstance(in_dict[key][0], (str, np.int,
-                                                        np.float, np.complex)):
+                        if isinstance(in_dict[key][0], (str, int,
+                                                        float, complex)):
                             try:
                                 out_dict[out_key] = [float(val)
                                                      for val in in_dict[key]]
@@ -519,7 +519,7 @@ def _parse_value(in_val):
             return float(str(in_val))
         except ValueError:
             try:
-                return np.complex(str(in_val))
+                return np.complex128(str(in_val))
             except ValueError:
                 return str(in_val)
 
@@ -883,7 +883,7 @@ def _recursively_validate_dict(in_dict):
                             else n for n in in_dict[key]]
 
         if isinstance(in_dict[key], (np.int64, np.int32)):
-            in_dict[key] = np.int(in_dict[key])
+            in_dict[key] = int(in_dict[key])
 
         if isinstance(in_dict[key], dict):
             _recursively_validate_dict(in_dict[key])

--- a/hera_qm/omnical_metrics.py
+++ b/hera_qm/omnical_metrics.py
@@ -134,7 +134,7 @@ def write_metrics(metrics, filename=None, filetype='json'):
                     metrics_out[pol][key] = metrics[pol][key].tolist()
                 elif isinstance(metrics_out[pol][key], (dict, odict)):
                     if list(metrics_out[pol][key].values())[0].dtype == np.complex:
-                        metrics_out[pol][key] = odict([(j, metrics_out[pol][key][j].astype(np.str)) for j in metrics_out[pol][key]])
+                        metrics_out[pol][key] = odict([(j, metrics_out[pol][key][j].astype(str)) for j in metrics_out[pol][key]])
                     metrics_out[pol][key] = odict([(str(j), metrics_out[pol][key][j].tolist()) for j in metrics_out[pol][key]])
                 elif isinstance(metrics_out[pol][key], (np.bool, np.bool_)):
                     metrics_out[pol][key] = bool(metrics_out[pol][key])

--- a/hera_qm/omnical_metrics.py
+++ b/hera_qm/omnical_metrics.py
@@ -82,7 +82,7 @@ def load_omnical_metrics(filename):
                 if isinstance(metric[key2], (dict, odict)):
                     if isinstance(list(metric[key2].values())[0], list):
                         metric[key2] = odict([(int(i), np.array(metric[key2][i])) for i in metric[key2]])
-                    elif isinstance(list(metric[key2].values())[0], (np.unicode, np.unicode_)):
+                    elif isinstance(list(metric[key2].values())[0], (str, np.unicode_)):
                         metric[key2] = odict([(int(i), metric[key2][i].astype(np.complex128)) for i in metric[key2]])
 
                 elif isinstance(metric[key2], list):
@@ -133,12 +133,12 @@ def write_metrics(metrics, filename=None, filetype='json'):
                 if isinstance(metrics_out[pol][key], np.ndarray):
                     metrics_out[pol][key] = metrics[pol][key].tolist()
                 elif isinstance(metrics_out[pol][key], (dict, odict)):
-                    if list(metrics_out[pol][key].values())[0].dtype == np.complex:
+                    if list(metrics_out[pol][key].values())[0].dtype == complex:
                         metrics_out[pol][key] = odict([(j, metrics_out[pol][key][j].astype(str)) for j in metrics_out[pol][key]])
                     metrics_out[pol][key] = odict([(str(j), metrics_out[pol][key][j].tolist()) for j in metrics_out[pol][key]])
-                elif isinstance(metrics_out[pol][key], (np.bool, np.bool_)):
+                elif isinstance(metrics_out[pol][key], (bool, np.bool_)):
                     metrics_out[pol][key] = bool(metrics_out[pol][key])
-                elif isinstance(metrics_out[pol][key], np.float):
+                elif isinstance(metrics_out[pol][key], (float, np.float32, np.float64)):
                     metrics_out[pol][key] = float(metrics_out[pol][key])
                 elif isinstance(metrics_out[pol][key], np.integer):
                     metrics_out[pol][key] = int(metrics_out[pol][key])

--- a/hera_qm/tests/__init__.py
+++ b/hera_qm/tests/__init__.py
@@ -61,7 +61,7 @@ def recursive_compare_dicts(d1, d2):
                                                                                    )
         elif isinstance(d1[key], dict):
             recursive_compare_dicts(d1[key], d2[key])
-        elif isinstance(d1[key], (float, np.float, np.float32)):
+        elif isinstance(d1[key], (float, np.float32, np.float64)):
             assert np.allclose(d1[key], d2[key], equal_nan=True), ("key: {key} has type {key1_type} in d1 and {key2_type} in d2\n"
                                                                    "d1:  data has type {data1_type} and value {data1_val}\n"
                                                                    "d2:  data has type {data2_type} and value {data2_val}\n"

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -195,12 +195,10 @@ def test_write_metric_warning_json():
     warn_message = ["JSON-type files can still be written but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility."]
-    json_dict = uvtest.checkWarnings(metrics_io.write_metric_file,
-                                     [json_file, test_dict],
-                                     {'overwrite': True},
-                                     category=PendingDeprecationWarning,
-                                     nwarnings=1,
-                                     message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        json_dict = metrics_io.write_metric_file(json_file, test_dict, overwrite=True)
     assert os.path.exists(json_file)
     os.remove(json_file)
 
@@ -214,12 +212,12 @@ def test_write_metric_warning_pickle():
     warn_message = ["Pickle-type files can still be written but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility."]
-    pickle_dict = uvtest.checkWarnings(metrics_io.write_metric_file,
-                                       [pickle_file, test_dict],
-                                       {'overwrite': True},
-                                       category=PendingDeprecationWarning,
-                                       nwarnings=1,
-                                       message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        pickle_dict = metrics_io.write_metric_file(
+            pickle_file, test_dict, overwrite=True
+        )
     assert os.path.exists(pickle_file)
     os.remove(pickle_file)
 
@@ -293,20 +291,18 @@ def test_write_then_load_metric_warning_json():
     warn_message = ["JSON-type files can still be written but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    uvtest.checkWarnings(metrics_io.write_metric_file,
-                         [json_file, test_dict],
-                         {'overwrite': True},
-                         category=PendingDeprecationWarning, nwarnings=1,
-                         message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        metrics_io.write_metric_file(json_file, test_dict, overwrite=True)
     assert os.path.exists(json_file)
     # output_json = metrics_io.write_metric_file(json_file, test_dict)
     warn_message = ["JSON-type files can still be read but are no longer "
                     "written by default.\n"]
-    json_dict = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                     func_args=[json_file],
-                                     category=[PendingDeprecationWarning],
-                                     nwarnings=1,
-                                     message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        json_dict = metrics_io.load_metric_file(json_file)
     # This function recursively walks dictionary and compares
     # data types together with assert or np.allclose
     qmtest.recursive_compare_dicts(test_dict, json_dict)
@@ -321,20 +317,18 @@ def test_write_then_load_metric_warning_pickle():
     warn_message = ["Pickle-type files can still be written but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    uvtest.checkWarnings(metrics_io.write_metric_file,
-                         [pickle_file, test_dict],
-                         {'overwrite': True},
-                         category=PendingDeprecationWarning, nwarnings=1,
-                         message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        metrics_io.write_metric_file(pickle_file, test_dict, overwrite=True)
     assert os.path.exists(pickle_file)
     # output_json = metrics_io.write_metric_file(json_file, test_dict)
     warn_message = ["Pickle-type files can still be read but are no longer "
                     "written by default.\n"]
-    pickle_dict = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                       func_args=[pickle_file],
-                                       category=[PendingDeprecationWarning],
-                                       nwarnings=1,
-                                       message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        pickle_dict = metrics_io.load_metric_file(pickle_file)
     # This function recursively walks dictionary and compares
     # data types together with assert or np.allclose
     assert qmtest.recursive_compare_dicts(test_dict, pickle_dict)
@@ -349,11 +343,10 @@ def test_read_write_old_firstcal_json_files():
     warn_message = ["JSON-type files can still be read but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    test_metrics = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                        func_args=[json_infile],
-                                        category=PendingDeprecationWarning,
-                                        nwarnings=1,
-                                        message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        test_metrics = metrics_io.load_metric_file(json_infile)
     metrics_io.write_metric_file(test_file, test_metrics, overwrite=True)
     test_metrics_in = metrics_io.load_metric_file(test_file)
 
@@ -375,11 +368,10 @@ def test_read_write_old_omnical_json_files():
     warn_message = ["JSON-type files can still be read but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    test_metrics = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                        func_args=[json_infile],
-                                        category=PendingDeprecationWarning,
-                                        nwarnings=1,
-                                        message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        test_metrics = metrics_io.load_metric_file(json_infile)
     metrics_io.write_metric_file(test_file, test_metrics, overwrite=True)
     test_metrics_in = metrics_io.load_metric_file(test_file)
 
@@ -405,11 +397,10 @@ def test_read_write_new_ant_json_files():
     warn_message = ["JSON-type files can still be read but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    test_metrics = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                        func_args=[json_infile],
-                                        category=PendingDeprecationWarning,
-                                        nwarnings=1,
-                                        message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        test_metrics = metrics_io.load_metric_file(json_infile)
     metrics_io.write_metric_file(test_file, test_metrics, overwrite=True)
     test_metrics_in = metrics_io.load_metric_file(test_file)
 
@@ -434,16 +425,15 @@ def test_read_old_all_string_ant_json_files():
     warn_message = ["JSON-type files can still be read but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    test_metrics_old = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                            func_args=[old_json_infile],
-                                            category=PendingDeprecationWarning,
-                                            nwarnings=1,
-                                            message=warn_message)
-    test_metrics_new = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                            func_args=[new_json_infile],
-                                            category=PendingDeprecationWarning,
-                                            nwarnings=1,
-                                            message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        test_metrics_old = metrics_io.load_metric_file(old_json_infile)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        test_metrics_new = metrics_io.load_metric_file(new_json_infile)
+
     # The written hdf5 may have these keys that differ by design
     # so ignore them.
     test_metrics_old.pop('history', None)
@@ -490,18 +480,16 @@ def test_boolean_read_write_json():
     warn_message = ["JSON-type files can still be written but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    uvtest.checkWarnings(metrics_io.write_metric_file,
-                         [test_file, test_dict],
-                         {"overwrite": True},
-                         category=PendingDeprecationWarning, nwarnings=1,
-                         message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        metrics_io.write_metric_file(test_file, test_dict, overwrite=True)
     warn_message = ["JSON-type files can still be read but are no longer "
                     "written by default.\n"]
-    json_dict = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                     func_args=[test_file],
-                                     category=[PendingDeprecationWarning],
-                                     nwarnings=1,
-                                     message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        json_dict = metrics_io.load_metric_file(test_file)
     assert test_dict['good_sol'] == json_dict['good_sol']
     assert isinstance(json_dict['good_sol'], (np.bool_, bool))
     os.remove(test_file)
@@ -515,17 +503,17 @@ def test_boolean_read_write_pickle():
     warn_message = ["Pickle-type files can still be written but are no longer "
                     "written by default.\n"
                     "Write to HDF5 format for future compatibility.", ]
-    uvtest.checkWarnings(metrics_io.write_metric_file,
-                         [test_file, test_dict],
-                         category=PendingDeprecationWarning, nwarnings=1,
-                         message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        metrics_io.write_metric_file(test_file, test_dict)
+
     warn_message = ["Pickle-type files can still be read but are no longer "
                     "written by default.\n"]
-    input_dict = uvtest.checkWarnings(metrics_io.load_metric_file,
-                                      func_args=[test_file],
-                                      category=[PendingDeprecationWarning],
-                                      nwarnings=1,
-                                      message=warn_message)
+    with uvtest.check_warnings(
+            PendingDeprecationWarning, match=warn_message, nwarnings=1
+    ):
+        input_dict = metrics_io.load_metric_file(test_file)
     assert test_dict['good_sol'] == input_dict['good_sol']
     assert isinstance(input_dict['good_sol'], (np.bool_, bool))
     os.remove(test_file)

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -345,7 +345,7 @@ def test_detrend_meanfilt_flags(fake_data):
         fake_data[:, i] = i * np.ones_like(fake_data[:, i])
     ind = int(fake_data.shape[0] / 2)
     fake_data[ind, :] = 10000.
-    flags = np.zeros(fake_data.shape, dtype=np.bool)
+    flags = np.zeros(fake_data.shape, dtype=np.bool_)
     flags[ind, :] = True
     # run detrend medfilt
     Kt = 8
@@ -373,7 +373,7 @@ def test_zscore_full_array_flags(fake_data):
     # Make some fake data
     np.random.seed(182)
     fake_data[...] = np.random.randn(fake_data.shape[0], fake_data.shape[1])
-    flags = np.zeros(fake_data.shape, dtype=np.bool)
+    flags = np.zeros(fake_data.shape, dtype=np.bool_)
     flags[45, 33] = True
     out = xrfi.zscore_full_array(fake_data, flags=flags)
     fake_mean = np.mean(np.ma.masked_array(fake_data, flags))
@@ -436,7 +436,7 @@ def test_watershed_flag():
 
     # set metric and flag arrays to specific values
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[0, 0, 1, 0] = 7.
     uvf.flag_array[0, 0, 0, 0] = True
 
@@ -444,13 +444,13 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[0, 0, :2, 0] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
     # test flagging channels adjacent to fully flagged ones
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[:, :, 1, :] = 1.
     uvf.flag_array[:, :, 0, :] = True
 
@@ -458,13 +458,13 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., nsig_f=0.5, inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:, :, :2, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
     # test flagging times adjacent to fully flagged ones
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     times = np.unique(uv.time_array)
     inds1 = np.where(uv.time_array == times[0])[0]
     inds2 = np.where(uv.time_array == times[1])[0]
@@ -475,7 +475,7 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., nsig_t=0.5, inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[inds1, 0, :, 0] = True
     flag_array[inds2, 0, :, 0] = True
     assert np.allclose(uvf.flag_array, flag_array)
@@ -488,7 +488,7 @@ def test_watershed_flag():
 
     # set metric and flag arrays to specific values
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[0, 0, 0, 1, 0] = 7.
     uvf.flag_array[0, 0, 0, 0, 0] = True
 
@@ -496,13 +496,13 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[0, 0, 0, :2, 0] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
     # test flagging channels adjacent to fully flagged ones
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[:, :, 1, :, :] = 1.
     uvf.flag_array[:, :, 0, :, :] = True
 
@@ -510,14 +510,14 @@ def test_watershed_flag():
     uvf2 = xrfi.watershed_flag(uvm, uvf, nsig_p=2., nsig_f=0.5, inplace=False)
 
     # check answer
-    flag_array = np.zeros_like(uvf2.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf2.flag_array, dtype=np.bool_)
     flag_array[:, :, :2, :, :] = True
     assert np.allclose(uvf2.flag_array, flag_array)
     del(uvf2)
 
     # test flagging times adjacent to fully flagged ones
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[:, :, :, 1, :] = 1.
     uvf.flag_array[:, :, :, 0, :] = True
 
@@ -525,7 +525,7 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., nsig_t=0.5, inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:, :, :, :2, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -537,7 +537,7 @@ def test_watershed_flag():
 
     # set metric and flag arrays to specific values
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[0, 1, 0] = 7.
     uvf.flag_array[0, 0, 0] = True
 
@@ -545,13 +545,13 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[0, :2, 0] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
     # test flagging channels adjacent to fully flagged ones
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[:, 1, :] = 1.
     uvf.flag_array[:, 0, :] = True
 
@@ -559,13 +559,13 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., nsig_f=0.5, inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:, :2, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
     # test flagging times adjacent to fully flagged ones
     uvm.metric_array = np.zeros_like(uvm.metric_array)
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvm.metric_array[1, :, :] = 1.
     uvf.flag_array[0, :, :] = True
 
@@ -573,7 +573,7 @@ def test_watershed_flag():
     xrfi.watershed_flag(uvm, uvf, nsig_p=2., nsig_t=0.5, inplace=True)
 
     # check answer
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:2, :, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -599,11 +599,11 @@ def test_watershed_flag_errors():
 def test_ws_flag_waterfall():
     # test 1d
     d = np.zeros((10,))
-    f = np.zeros((10,), dtype=np.bool)
+    f = np.zeros((10,), dtype=np.bool_)
     d[1] = 3.
     f[0] = True
     f_out = xrfi._ws_flag_waterfall(d, f, nsig=2.)
-    ans = np.zeros_like(f_out, dtype=np.bool)
+    ans = np.zeros_like(f_out, dtype=np.bool_)
     ans[:2] = True
     assert np.allclose(f_out, ans)
 
@@ -615,22 +615,22 @@ def test_ws_flag_waterfall():
 
     # test 2d
     d = np.zeros((10, 10))
-    f = np.zeros((10, 10), dtype=np.bool)
+    f = np.zeros((10, 10), dtype=np.bool_)
     d[0, 1] = 3.
     d[1, 0] = 3.
     f[0, 0] = True
     f_out = xrfi._ws_flag_waterfall(d, f, nsig=2.)
-    ans = np.zeros_like(f_out, dtype=np.bool)
+    ans = np.zeros_like(f_out, dtype=np.bool_)
     ans[:2, 0] = True
     ans[0, :2] = True
     assert np.allclose(f_out, ans)
 
     # catch errors
     d1 = np.zeros((10,))
-    f2 = np.zeros((10, 10), dtype=np.bool)
+    f2 = np.zeros((10, 10), dtype=np.bool_)
     pytest.raises(ValueError, xrfi._ws_flag_waterfall, d1, f2)
     d3 = np.zeros((5, 4, 3))
-    f3 = np.zeros((5, 4, 3), dtype=np.bool)
+    f3 = np.zeros((5, 4, 3), dtype=np.bool_)
     pytest.raises(ValueError, xrfi._ws_flag_waterfall, d3, f3)
 
 
@@ -685,7 +685,7 @@ def test_flag():
     uvm.metric_array[0, 0, 0, 0] = 7.
     uvf = xrfi.flag(uvm, nsig_p=6.)
     assert uvf.mode == 'flag'
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[0, 0, 0, 0] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -694,7 +694,7 @@ def test_flag():
     uvm.metric_array[:, :, 0, :] = 7.
     uvm.metric_array[:, :, 1, :] = 3.
     uvf = xrfi.flag(uvm, nsig_p=6., nsig_f=2.)
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:, :, :2, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -706,7 +706,7 @@ def test_flag():
     uvm.metric_array[inds1, :, :, :] = 7.
     uvm.metric_array[inds2, :, :, :] = 3.
     uvf = xrfi.flag(uvm, nsig_p=6., nsig_t=2.)
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[inds1, :, :, :] = True
     flag_array[inds2, :, :, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
@@ -719,7 +719,7 @@ def test_flag():
     uvm.metric_array[:, :, 0, :, :] = 7.
     uvm.metric_array[:, :, 1, :, :] = 3.
     uvf = xrfi.flag(uvm, nsig_p=7., nsig_f=2.)
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:, :, :2, :, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -728,7 +728,7 @@ def test_flag():
     uvm.metric_array[:, :, :, 0, :] = 7.
     uvm.metric_array[:, :, :, 1, :] = 3.
     uvf = xrfi.flag(uvm, nsig_p=6., nsig_t=2.)
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:, :, :, :2, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -740,7 +740,7 @@ def test_flag():
     uvm.metric_array[:, 0, :] = 7.
     uvm.metric_array[:, 1, :] = 3.
     uvf = xrfi.flag(uvm, nsig_p=6., nsig_f=2.)
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:, :2, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -749,7 +749,7 @@ def test_flag():
     uvm.metric_array[0, :, :] = 7.
     uvm.metric_array[1, :, :] = 3.
     uvf = xrfi.flag(uvm, nsig_p=6., nsig_t=2.)
-    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     flag_array[:2, :, :] = True
     assert np.allclose(uvf.flag_array, flag_array)
 
@@ -768,9 +768,9 @@ def test_flag_apply():
     # test applying to UVData
     uv = UVData()
     uv.read_miriad(test_d_file)
-    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool)
+    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool_)
     uvf = UVFlag(uv, mode='flag')
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvf.flag_array[:, :, 0, :] = True
     uvf2 = xrfi.flag_apply(uvf, uv, return_net_flags=True)
     assert np.allclose(uv.flag_array, uvf2.flag_array)
@@ -778,9 +778,9 @@ def test_flag_apply():
     # test applying to UVCal
     uv = UVCal()
     uv.read_calfits(test_c_file)
-    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool)
+    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool_)
     uvf = UVFlag(uv, mode='flag')
-    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool)
+    uvf.flag_array = np.zeros_like(uvf.flag_array, dtype=np.bool_)
     uvf.flag_array[:, :, 0, :, :] = True
     uvf2 = xrfi.flag_apply(uvf, uv, return_net_flags=True)
     assert np.allclose(uv.flag_array, uvf2.flag_array)
@@ -788,7 +788,7 @@ def test_flag_apply():
     # test applying to waterfalls
     uv = UVData()
     uv.read_miriad(test_d_file)
-    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool)
+    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool_)
     uvf = UVFlag(uv, mode='flag', waterfall=True)
     uvf.flag_array[:, 0, :] = True
     xrfi.flag_apply(uvf, uv)
@@ -797,7 +797,7 @@ def test_flag_apply():
 
     uv = UVCal()
     uv.read_calfits(test_c_file)
-    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool)
+    uv.flag_array = np.zeros_like(uv.flag_array, dtype=np.bool_)
     uvf = UVFlag(uv, mode='flag', waterfall=True)
     uvf.flag_array[:, 0, :] = True
     xrfi.flag_apply(uvf, uv)

--- a/hera_qm/vis_metrics.py
+++ b/hera_qm/vis_metrics.py
@@ -129,7 +129,7 @@ def sequential_diff(data, t_int=None, axis=(0,), pad=True, run_check=True, histo
         if pad:
             for ax in axis:
                 # get padding vector
-                zero_slice = utils.dynamic_slice(np.zeros_like(data, dtype=np.float), slice(0, 1), axis=ax)
+                zero_slice = utils.dynamic_slice(np.zeros_like(data, dtype=np.float64), slice(0, 1), axis=ax)
                 # pad arrays
                 data = np.concatenate([data, zero_slice], axis=ax)
                 t_int = np.concatenate([t_int, zero_slice], axis=ax)
@@ -304,8 +304,8 @@ def vis_bl_bl_cov(uvd1, uvd2, bls, iterax=None, return_corr=False):
     for bl in bls:
         d1[bl] = uvd1.get_data(bl)
         d2[bl] = uvd2.get_data(bl)
-        w1[bl] = (~uvd1.get_flags(bl)).astype(np.float)
-        w2[bl] = (~uvd2.get_flags(bl)).astype(np.float)
+        w1[bl] = (~uvd1.get_flags(bl)).astype(np.float64)
+        w2[bl] = (~uvd2.get_flags(bl)).astype(np.float64)
         m1[bl] = (np.sum(d1[bl] * w1[bl], axis=sumaxes, keepdims=True)
                   / np.sum(w1[bl], axis=sumaxes, keepdims=True).clip(1e-10, np.inf))
         m2[bl] = (np.sum(d2[bl] * w2[bl], axis=sumaxes, keepdims=True)
@@ -313,7 +313,7 @@ def vis_bl_bl_cov(uvd1, uvd2, bls, iterax=None, return_corr=False):
 
     # setup empty cov array
     Nbls = len(bls)
-    cov = np.empty((Nbls, Nbls, Ntimes, Nfreqs), dtype=np.complex) * np.nan
+    cov = np.empty((Nbls, Nbls, Ntimes, Nfreqs), dtype=np.complex128) * np.nan
 
     # iterate over bls
     for bl1i, bl1 in enumerate(bls):
@@ -336,7 +336,7 @@ def vis_bl_bl_cov(uvd1, uvd2, bls, iterax=None, return_corr=False):
     # calculate correlation matrix
     if return_corr:
         # get stds of bls
-        std = np.empty((2, Nbls, Ntimes, Nfreqs), dtype=np.complex) * np.nan
+        std = np.empty((2, Nbls, Ntimes, Nfreqs), dtype=np.complex128) * np.nan
         for bli, bl in enumerate(bls):
             d1diff = d1[bl] - m1[bl]
             std[0, bli] = np.sqrt(np.abs(np.sum(d1diff * d1diff.conj() * w1[bl],
@@ -626,8 +626,8 @@ def plot_bl_bl_scatter(uvd1, uvd2, bls, component='real', whiten=False, colorbar
                 # data key didn't exist...
                 d1 = np.zeros_like(color)
                 d2 = np.zeros_like(color)
-                f1 = np.ones_like(color, dtype=np.bool)
-                f2 = np.ones_like(color, dtype=np.bool)
+                f1 = np.ones_like(color, dtype=np.bool_)
+                f2 = np.ones_like(color, dtype=np.bool_)
 
             d1[f1] *= np.nan
             d2[f2] *= np.nan

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1966,15 +1966,15 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     if ocalfits_files is None and acalfits_files is None and model_files is None and data_files is None:
         raise ValueError("Must provide at least one of the following; ocalfits_files, acalfits_files, model_files, data_files")
     # user must provide an optional output prefix if no data file is provided.
-    if isinstance(acalfits_files, (str, np.str)):
+    if isinstance(acalfits_files, (str, np.string_)):
         acalfits_files = [acalfits_files]
-    if isinstance(ocalfits_files, (str, np.str)):
+    if isinstance(ocalfits_files, (str, np.string_)):
         ocalfits_files = [ocalfits_files]
-    if isinstance(model_files, (str, np.str)):
+    if isinstance(model_files, (str, np.string_)):
         model_files = [model_files]
-    if isinstance(data_files, (str, np.str)):
+    if isinstance(data_files, (str, np.string_)):
         data_files = [data_files]
-    if isinstance(output_prefixes, (str, np.str)):
+    if isinstance(output_prefixes, (str, np.string_)):
         output_prefixes = [output_prefixes]
     if output_prefixes is None:
         if data_files is not None:

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -656,7 +656,7 @@ def watershed_flag(uvf_m, uvf_f, nsig_p=2., nsig_f=None, nsig_t=None, avg_method
             # Time watershed
             ts = np.unique(uvf.time_array)
             tempd = np.zeros(ts.size)
-            tempf = np.zeros(ts.size, dtype=np.bool)
+            tempf = np.zeros(ts.size, dtype=np.bool_)
             for ti, time in enumerate(ts):
                 tempd[ti] = uvutils.collapse(marr[uvf.time_array == time, 0, :, :], avg_method,
                                              weights=warr[uvf.time_array == time, 0, :, :])
@@ -1170,9 +1170,9 @@ def calculate_metric(uv, algorithm, cal_mode='gain', run_check=True,
         raise KeyError('Algorithm not found in list of available functions.')
     uvf = UVFlag(uv)
     if issubclass(uv.__class__, UVData):
-        uvf.weights_array = uv.nsample_array * np.logical_not(uv.flag_array).astype(np.float)
+        uvf.weights_array = uv.nsample_array * np.logical_not(uv.flag_array).astype(np.float64)
     else:
-        uvf.weights_array = np.logical_not(uv.flag_array).astype(np.float)
+        uvf.weights_array = np.logical_not(uv.flag_array).astype(np.float64)
     if issubclass(uv.__class__, UVData):
         for key, data in uv.antpairpol_iter():
             ind1, ind2, pol = uv._key2inds(key)
@@ -1376,10 +1376,10 @@ def xrfi_pipe(uv, alg='detrend_medfilt', Kt=8, Kf=8, xants=[], cal_mode='gain',
     if center_metric:
         # Pass the z-scores through the filter again to get a zero-centered, width-of-one distribution.
         uvf_m.metric_array[:, :, 0] = alg_func(uvf_m.metric_array[:, :, 0],
-                                               flags=~(uvf_m.weights_array[:, :, 0].astype(np.bool)),
+                                               flags=~(uvf_m.weights_array[:, :, 0].astype(np.bool_)),
                                                Kt=Kt, Kf=Kf)
     if reset_weights:
-        uvf_m.weights_array = uvf_m.weights_array.astype(np.bool).astype(np.float)
+        uvf_m.weights_array = uvf_m.weights_array.astype(np.bool_).astype(np.float64)
     if not skip_flags:
         uvf_f = flag(uvf_m, nsig_p=sig_init, run_check=run_check,
                      check_extra=check_extra,
@@ -1439,11 +1439,11 @@ def chi_sq_pipe(uv, alg='zscore_full_array', modified=False, sig_init=6.0,
                        run_check_acceptability=run_check_acceptability)
     # This next line resets the weights to 1 (with data) or 0 (no data) to equally
     # combine with the other metrics.
-    uvf_m.weights_array = uvf_m.weights_array.astype(np.bool).astype(np.float)
+    uvf_m.weights_array = uvf_m.weights_array.astype(np.bool_).astype(np.float64)
     alg_func = algorithm_dict[alg]
     # Pass the z-scores through the filter again to get a zero-centered, width-of-one distribution.
     uvf_m.metric_array[:, :, 0] = alg_func(uvf_m.metric_array[:, :, 0], modified=modified,
-                                           flags=~(uvf_m.weights_array[:, :, 0].astype(np.bool)))
+                                           flags=~(uvf_m.weights_array[:, :, 0].astype(np.bool_)))
     # Flag and watershed on waterfall
     uvf_f = flag(uvf_m, nsig_p=sig_init, run_check=run_check,
                  check_extra=check_extra,
@@ -2109,7 +2109,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         vdict['uvf_metrics'].label = 'Combined metrics, round 1.'
         alg_func = algorithm_dict['detrend_medfilt']
         vdict['uvf_metrics'].metric_array[:, :, 0] = alg_func(vdict['uvf_metrics'].metric_array[:, :, 0],
-                                                     flags=~vdict['uvf_metrics'].weights_array[:, :, 0].astype(np.bool),
+                                                     flags=~vdict['uvf_metrics'].weights_array[:, :, 0].astype(np.bool_),
                                                      Kt=kt_size, Kf=kf_size)
 
         # Flag on combined metrics
@@ -2469,7 +2469,7 @@ def xrfi_h3c_idr2_1_run(ocalfits_files, acalfits_files, model_files, data_files,
     uvf_metrics.label = 'Combined metrics, round 1.'
     alg_func = algorithm_dict['detrend_medfilt']
     uvf_metrics.metric_array[:, :, 0] = alg_func(uvf_metrics.metric_array[:, :, 0],
-                                                 flags=~uvf_metrics.weights_array[:, :, 0].astype(np.bool),
+                                                 flags=~uvf_metrics.weights_array[:, :, 0].astype(np.bool_),
                                                  Kt=kt_size, Kf=kf_size)
 
     # Flag on combined metrics


### PR DESCRIPTION
In the upgrade to numpy v1.20, [several datatypes like `np.int` were formally deprecated](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated). This led to the incorrect number of warnings being raised for some hera_qm tests, so they were failing. This PR removes references to the deprecated types, and cleans up some of the tests in the process.