### PR TITLE
Break file loading in ant_metrics into its own function to prevent memory leaks

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -304,7 +304,7 @@ class AntennaMetrics():
             self.removal_iteration[ant] = -1
 
     def _load_files_and_update_corr_stats(self, corr_stats, sum_files, diff_files, bl_load_groups):
-        """Loop over baseline groups and sum/diff files, extending the existing corr_stats dict of lists.
+        """Loop over baseline groups, loading sum/diff files and extending the existing corr_stats dict of lists.
         """
         # loop over baseline groups
         for blg in bl_load_groups:


### PR DESCRIPTION
Right now, ant_metrics is taking more than 128 GB of memory when running on 10 files and appears to be leaking memory quite badly:

![image](https://user-images.githubusercontent.com/5281139/144320087-31686206-32a6-4857-b0af-101ef6eae0f2.png)

This PR breaks file loading into a function, which is looped over per files group, to help make sure everything goes out of scope as appropriate.