### PR TITLE
Add option to ignore cross-polarized visibilities in XRFI

### DIFF
--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -1042,6 +1042,18 @@ def test_xrfi_run_step(tmpdir):
     assert np.all(np.isclose(uvf_f1x.flag_array, uvf_f2x.flag_array))
     assert np.all(np.isclose(uvf_a1x.flag_array, uvf_a2x.flag_array))
 
+    # test use_cross_pol_vis (since the file is all a single pol, the results should be the same)
+    uv3, uvf3, uvf_f3, uvf_a3, metrics3, flags3 = xrfi.xrfi_run_step(uv_files=raw_dfile,
+                                                                     calculate_uvf_apriori=True,
+                                                                     run_filter=True, dtype='uvdata',
+                                                                     use_cross_pol_vis=False,
+                                                                     wf_method='quadmean',
+                                                                     alg='detrend_medfilt',
+                                                                     correlations='cross')
+    assert np.all(np.isclose(uvf_f1.flag_array, uvf_f3.flag_array))
+    assert np.all(np.isclose(uvf_a1.flag_array, uvf_a3.flag_array))
+    assert np.all(np.isclose(uvf1.metric_array, uvf3.metric_array))
+
     # comparison for meanfilter.
     uv1, uvf1, uvf_f1, uvf_a1, metrics1, flags1 = xrfi.xrfi_run_step(uv_files=raw_dfile,
     calculate_uvf_apriori=True, run_filter=True, dtype='uvdata', wf_method='mean', alg='detrend_meanfilt')

--- a/hera_qm/utils.py
+++ b/hera_qm/utils.py
@@ -292,6 +292,8 @@ def get_metrics_ArgumentParser(method_name):
                               'antenna flagsfor parsable by hera_qm.metrics_io.read_a_priori_*_flags()'))
         ap.add_argument('--a_apriori_times_and_freqs', default=False, action="store_true",
                         help="If True, ignore frequeny and time flags in apriori yaml file (only use ant flags).")
+        ap.add_argument('--skip_cross_pol_vis', default=False, action="store_true",
+                        help="Don't load or use cross-polarized visibilities, e.g. 'en' or 'ne', in flagging.")
         ap.add_argument('--xrfi_path', default='', type=str,
                         help='Path to save flag files to. Default is same directory as input file.')
         ap.add_argument('--kt_size', default=8, type=int,
@@ -343,6 +345,8 @@ def get_metrics_ArgumentParser(method_name):
         ap.add_argument('--a_priori_flag_yaml', default=None, type=str,
                         help=('Path to a priori flagging YAML with frequency, time, and/or '
                               'antenna flagsfor parsable by hera_qm.metrics_io.read_a_priori_*_flags()'))
+        ap.add_argument('--skip_cross_pol_vis', default=False, action="store_true",
+                        help="Don't load or use cross-polarized visibilities, e.g. 'en' or 'ne', in flagging.")
         ap.add_argument('--xrfi_path', default='', type=str,
                         help='Path to save flag files to. Default is same directory as input file.')
         ap.add_argument('--kt_size', default=8, type=int,

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1464,6 +1464,7 @@ def xrfi_run_step(uv_files=None, uv=None, uvf_apriori=None,
                   metrics=None, flags=None, modified_z_score=False,
                   a_priori_flag_yaml=None,
                   a_priori_ants_only=False,
+                  use_cross_pol_vis=True,
                   run_check=True,
                   check_extra=True,
                   run_check_acceptability=True):
@@ -1571,6 +1572,8 @@ def xrfi_run_step(uv_files=None, uv=None, uvf_apriori=None,
         See hera_qm.metrics_io.read_a_priori_[chan/int/ant]_flags() for details.
     a_priori_ants_only : bool, optional
         if True, only apply antenna flags from apriori yaml.
+    use_cross_pol_vis : bool, optionl
+        If True (default), also load and flag on cross-polarized visibilities (e.g. 'ne'/'en')
     run_check : bool
         Option to check for the existence and proper shapes of parameters
         on UVFlag Object.
@@ -1647,6 +1650,9 @@ def xrfi_run_step(uv_files=None, uv=None, uvf_apriori=None,
         # The following code applies if uv is a UVData object.
         if issubclass(uv.__class__, UVData):
             bls = uv.get_antpairpols()
+            if not use_cross_pol_vis:
+                # cut baselines whose polarization is not the same as its conjugate (e.g. 'ne')
+                bls = [app for app in bls if (app[2] == uvutils.conj_pol(app[2]))]
             if correlations == 'cross':
                 bls = [app for app in bls if app[1] != app[0]]
             elif correlations == 'auto':

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1572,7 +1572,7 @@ def xrfi_run_step(uv_files=None, uv=None, uvf_apriori=None,
         See hera_qm.metrics_io.read_a_priori_[chan/int/ant]_flags() for details.
     a_priori_ants_only : bool, optional
         if True, only apply antenna flags from apriori yaml.
-    use_cross_pol_vis : bool, optionl
+    use_cross_pol_vis : bool, optional
         If True (default), also load and flag on cross-polarized visibilities (e.g. 'ne'/'en')
     run_check : bool
         Option to check for the existence and proper shapes of parameters
@@ -1776,7 +1776,7 @@ def xrfi_run_step(uv_files=None, uv=None, uvf_apriori=None,
 
 def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
              data_files=None, a_priori_flag_yaml=None,
-             a_priori_ants_only=False,
+             a_priori_ants_only=False, use_cross_pol_vis=True,
              omnical_median_filter=True, omnical_mean_filter=True,
              omnical_chi2_median_filter=True, omnical_chi2_mean_filter=True,
              omnical_zscore_filter=True,
@@ -1825,6 +1825,8 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         Default is False.
         WARNING: Default can cause excess flags in the vicinity the apriori regions
         due to edge effects.
+    use_cross_pol_vis : bool, optional
+        If True (default), also load and flag on cross-polarized visibilities (e.g. 'ne'/'en')
     omnical_median_filter : bool, optional
         If true, run a median filter on omnical gains.
         Mean filters are run after median filters.
@@ -2051,6 +2053,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                                                                                      calculate_uvf_apriori=True, modified_z_score=True,
                                                                                      a_priori_flag_yaml=a_priori_flag_yaml,
                                                                                      a_priori_ants_only=a_priori_ants_only,
+                                                                                     use_cross_pol_vis=use_cross_pol_vis,
                                                                                      run_check=run_check, check_extra=check_extra,
                                                                                      run_check_acceptability=run_check_acceptability)
     # to do the abscal filters, just change
@@ -2068,6 +2071,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                                                                                      calculate_uvf_apriori=True, modified_z_score=True,
                                                                                      a_priori_flag_yaml=a_priori_flag_yaml,
                                                                                      a_priori_ants_only=a_priori_ants_only,
+                                                                                     use_cross_pol_vis=use_cross_pol_vis,
                                                                                      run_check=run_check, check_extra=check_extra,
                                                                                      run_check_acceptability=run_check_acceptability)
     # now we perform first-round filters on our uvdata inputs.
@@ -2098,6 +2102,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                                                                                                   correlations=corr, calculate_uvf_apriori=True, modified_z_score=True,
                                                                                                   a_priori_flag_yaml=a_priori_flag_yaml,
                                                                                                   a_priori_ants_only=a_priori_ants_only,
+                                                                                                  use_cross_pol_vis=use_cross_pol_vis,
                                                                                                   run_check=run_check, check_extra=check_extra,
                                                                                                   run_check_acceptability=run_check_acceptability)
     # Now that we've had a chance to load in all of the provided data products and
@@ -2160,6 +2165,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                                                                                     calculate_uvf_apriori=False,
                                                                                     a_priori_flag_yaml=a_priori_flag_yaml,
                                                                                     a_priori_ants_only=a_priori_ants_only,
+                                                                                    use_cross_pol_vis=use_cross_pol_vis,
                                                                                     run_check=run_check, check_extra=check_extra,
                                                                                     run_check_acceptability=run_check_acceptability)
     # Meanfilter abscal. Note that init flags are pased as apriori_flags.
@@ -2175,6 +2181,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                                                                                     calculate_uvf_apriori=False,
                                                                                     a_priori_flag_yaml=a_priori_flag_yaml,
                                                                                     a_priori_ants_only=a_priori_ants_only,
+                                                                                    use_cross_pol_vis=use_cross_pol_vis,
                                                                                     run_check=run_check, check_extra=check_extra,
                                                                                     run_check_acceptability=run_check_acceptability)
     # mean filter omnivis and data files.
@@ -2196,6 +2203,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                                                                                calculate_uvf_apriori=False,
                                                                                a_priori_flag_yaml=a_priori_flag_yaml,
                                                                                a_priori_ants_only=a_priori_ants_only,
+                                                                               use_cross_pol_vis=use_cross_pol_vis,
                                                                                run_check=run_check, check_extra=check_extra,
                                                                                run_check_acceptability=run_check_acceptability)
     if len(metrics) > 0:

--- a/scripts/xrfi_run.py
+++ b/scripts/xrfi_run.py
@@ -14,6 +14,7 @@ history = ' '.join(sys.argv)
 xrfi.xrfi_run(args.ocalfits_files, args.acalfits_files, args.model_files,
               args.data_files, a_priori_flag_yaml=args.a_priori_flag_yaml,
               a_priori_ants_only=not(args.a_apriori_times_and_freqs),
+              use_cross_pol_vis=not(args.skip_cross_pol_vis),
               history=history, xrfi_path=args.xrfi_path, throw_away_edges=not(args.keep_edge_times),
               kt_size=args.kt_size, kf_size=args.kf_size, sig_init=args.sig_init,
               sig_adj=args.sig_adj, ex_ants=args.ex_ants,

--- a/scripts/xrfi_run_data_only.py
+++ b/scripts/xrfi_run_data_only.py
@@ -12,6 +12,7 @@ args = ap.parse_args()
 history = ' '.join(sys.argv)
 
 xrfi.xrfi_run(data_files=args.data_files, a_priori_flag_yaml=args.a_priori_flag_yaml,
+              use_cross_pol_vis=not(args.skip_cross_pol_vis),
               cross_median_filter=args.cross_median_filter,
               cross_mean_filter=not(args.skip_cross_mean_filter),
               history=history, xrfi_path=args.xrfi_path, throw_away_edges=not(args.keep_edge_times),


### PR DESCRIPTION
I've been investigating how to make XRFI run more quickly on site.

I was under the impression for a while that this was actually how XRFI worked when looking at only autos, though I just figured out that that's not the case.

This PR leaves the status quo as the default. Whether we want to use this option in future stage 2 XRFI is an open question. 