### PR TITLE
Add time_atol to flag_apply to fix XRFI overflagging

### DIFF
--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -2021,7 +2021,8 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                          omnical_filter, omnical_chi2_filter, omnical_zscore_filter, 
                          abscal_filter, abscal_chi2_filter, abscal_zscore_filter,
                          omnivis_filter, cross_filter, auto_filter):
-        '''This function runs all possible filters, updating vdict as appropriate'''
+        '''This function runs all possible filters, updating vdict as appropriate. 
+        rnd_label is "mean" or "median". All other args are booleans for whether to run that filter type.'''
         
         # Start with empty list of flags and metrics for later combination
         metrics = []

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+    # -*- coding: utf-8 -*-
 # Copyright (c) 2019 the HERA Project
 # Licensed under the MIT License
 """Module for performing RFI identification and excision."""
@@ -2013,11 +2013,11 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     # are ultimately referenced by vdict but could be set to None. Outputs set to None are simply
     # not written and can be used to determine whether steps depending on them should be run.
     vdict={'uvf_apriori': None,
-    'uvf_init': None, 'uvf_fws': None, 'uvf_f': None, 'uvf_metrics': None,
-    'uvf_metrics2': None, 'uvf_f2': None, 'uvf_fws2': None,
-    'uvf_combined2': None, 'uvc_o':None, 'uvc_a':None, 'uvc_v':None, 'uv_v':None, 'uv_d':None} # keep all the variables here.
+           'uvf_init': None, 'uvf_fws': None, 'uvf_f': None, 'uvf_metrics': None,
+           'uvf_metrics2': None, 'uvf_f2': None, 'uvf_fws2': None,
+           'uvf_combined2': None, 'uvc_o':None, 'uvc_a':None, 'uvc_v':None, 'uv_v':None, 'uv_d':None} # keep all the variables here.
 
-    def _run_all_filters(median_round, 
+    def _run_all_filters(rnd_label, 
                          omnical_filter, omnical_chi2_filter, omnical_zscore_filter, 
                          abscal_filter, abscal_chi2_filter, abscal_zscore_filter,
                          omnivis_filter, cross_filter, auto_filter):
@@ -2028,23 +2028,22 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         flags = []
         
         # Modify these labels and parameters based on whether we're doing mean- or median-based statistics
-        label = {True: 'median', False: 'mean'}[median_round]
-        rnd = {True: '', False: '2'}[median_round]
-        rndnum = {True: '1', False: '2'}[median_round]
-        alg = {True: 'detrend_medfilt', False: 'detrend_meanfilt'}[median_round]
-        modified = {True: 'modified ', False: ''}[median_round]
-        start_flag_name = {True: 'uvf_apriori', False: 'uvf_init'}[median_round]
-        final_flag_name = {True: 'uvf_init', False: 'uvf_combined2'}[median_round]
+        rnd = {'median': '', 'mean': '2'}[rnd_label]
+        rndnum = {'median': '1', 'mean': '2'}[rnd_label]
+        alg = {'median': 'detrend_medfilt', 'mean': 'detrend_meanfilt'}[rnd_label]
+        modified = {'median': 'modified ', 'mean': ''}[rnd_label]
+        start_flag_name = {'median': 'uvf_apriori', 'mean': 'uvf_init'}[rnd_label]
+        final_flag_name = {'median': 'uvf_init', 'mean': 'uvf_combined2'}[rnd_label]
 
         # Median/mean filter omnical gains and chi^2
         if omnical_filter:
             (vdict['uvc_o'], vdict[f'uvf_og{rnd}'], vdict[f'uvf_ogf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg=alg, cal_mode='gain', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
-                              reinitialize=False, label=f'Omnical gains, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
+                              reinitialize=False, label=f'Omnical gains, {rnd_label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if omnical_chi2_filter:
             (vdict['uvc_o'], vdict[f'uvf_ox{rnd}'], vdict[f'uvf_oxf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg=alg, cal_mode='tot_chisq', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
-                              reinitialize=False, label=f'Omnical chisq, {label} filter.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
+                              reinitialize=False, label=f'Omnical chisq, {rnd_label} filter.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
         if omnical_zscore_filter:
             (vdict['uvc_o'], vdict[f'uvf_oz{rnd}'], vdict[f'uvf_ozf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg='zscore_full_array', cal_mode=None, metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
@@ -2054,12 +2053,12 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         if abscal_filter:
             (vdict['uvc_a'], vdict[f'uvf_ag{rnd}'], vdict[f'uvf_agf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg=alg, cal_mode='gain', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
-                              reinitialize=False, label=f'Abscal gains, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
+                              reinitialize=False, label=f'Abscal gains, {rnd_label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if abscal_chi2_filter:
             (vdict['uvc_a'], vdict[f'uvf_ax{rnd}'], vdict[f'uvf_axf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg=alg, cal_mode='tot_chisq', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
-                              reinitialize=False, label=f'Abscal chisq, {label} filter.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
-        if abscal_zscore_filter:
+                              reinitialize=False, label=f'Abscal chisq, {rnd_label} filter.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
+        if abscal_zscore_filter:    
             (vdict['uvc_a'], vdict[f'uvf_az{rnd}'], vdict[f'uvf_azf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg='zscore_full_array', cal_mode=None, metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=False, label=f'Abscal overall {modified}z-score of chisq.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
@@ -2068,15 +2067,15 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         if omnivis_filter:
             (vdict['uv_v'], vdict[f'uvf_v{rnd}'], vdict[f'uvf_vf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uv_v'], uv_files=model_files, alg=alg,  dtype='uvdata', correlations='both', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
-                              reinitialize=True, label=f'Omnical visibility solutions, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
+                              reinitialize=True, label=f'Omnical visibility solutions, {rnd_label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if cross_filter:
             (vdict['uv_d'], vdict[f'uvf_d{rnd}'], vdict[f'uvf_df{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uv_d'], uv_files=data_files, alg=alg,  dtype='uvdata', correlations='cross', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
-                              reinitialize=True, label=f'Crosscorr, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
+                              reinitialize=True, label=f'Crosscorr, {rnd_label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if auto_filter:
             (vdict['uv_d'], vdict[f'uvf_da{rnd}'], vdict[f'uvf_daf{rnd}'], vdict[start_flag_name], metrics, flags) = \
                 xrfi_run_step(uv=vdict['uv_d'], uv_files=data_files, alg=alg,  dtype='uvdata', correlations='auto', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
-                              reinitialize=True, label=f'Autocorr, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
+                              reinitialize=True, label=f'Autocorr, {rnd_label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
 
         # Now that we've had a chance to load in all of the provided data products and run filters when specified, 
         # we combine the metrics computed so far into a combined metrics object, using the metrics list.
@@ -2086,8 +2085,8 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
             else:
                 vdict[f'uvf_metrics{rnd}'] = copy.deepcopy(metrics[-1])
             
-            # Prep starting flags for combined metrics    
-            if median_round:
+            # Prep starting flags for combined metrics
+            if rnd_label == 'median':
                 flags_for_combined_metrics = ~vdict[f'uvf_metrics{rnd}'].weights_array[:, :, 0].astype(np.bool_)
             else:
                 if vdict['uvf_init'] is None:
@@ -2125,7 +2124,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     xrfi_run_step_kwargs['modified_z_score'] =  True 
     xrfi_run_step_kwargs['calculate_uvf_apriori'] = True
 
-    _run_all_filters(True, 
+    _run_all_filters('median', 
                      omnical_median_filter, omnical_chi2_median_filter, omnical_zscore_filter, 
                      abscal_median_filter, abscal_chi2_median_filter, abscal_zscore_filter,
                      omnivis_median_filter, cross_median_filter, auto_median_filter)
@@ -2141,7 +2140,7 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     xrfi_run_step_kwargs['calculate_uvf_apriori'] = False
 
     # Now perform the mean filtering after median filtering.
-    _run_all_filters(False, 
+    _run_all_filters('mean', 
                      omnical_mean_filter, omnical_chi2_mean_filter, omnical_zscore_filter, 
                      abscal_mean_filter, abscal_chi2_mean_filter, abscal_zscore_filter,
                      omnivis_mean_filter, cross_mean_filter, auto_mean_filter)

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1975,10 +1975,16 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         raise ValueError("Must provide at least one of the following; ocalfits_files, acalfits_files, model_files, data_files")
 
     # recast strings as lists of strings
-    for varname in ['acalfits_files', 'ocalfits_files', 'model_files', 'data_files', 'output_prefixes']:
-        if isinstance(eval(varname), (str, np.string_)):
-            exec(f'{varname} = [{varname}]') 
-            
+    def _recast_as_list_if_str(to_cast):
+        if isinstance(to_cast, (str, np.string_)):
+            to_cast = [to_cast]
+        return to_cast
+    acalfits_files = _recast_as_list_if_str(acalfits_files)
+    ocalfits_files = _recast_as_list_if_str(ocalfits_files)
+    model_files = _recast_as_list_if_str(model_files)
+    data_files = _recast_as_list_if_str(data_files)
+    output_prefixes = _recast_as_list_if_str(output_prefixes)
+
     # ensure that an optional output prefix if no data file is provided.
     if output_prefixes is None:
         if data_files is not None:

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -972,8 +972,8 @@ def threshold_wf(uvf_m, nsig_f=7., nsig_t=7., nsig_f_adj=3., nsig_t_adj=3.,
     return uvf_f
 
 
-def flag_apply(uvf, uv, keep_existing=True, force_pol=False, history='',
-               return_net_flags=False, run_check=True,
+def flag_apply(uvf, uv, keep_existing=True, force_pol=False, time_atol=1e-8,
+               history='', return_net_flags=False, run_check=True,
                check_extra=True, run_check_acceptability=True):
     """Apply flags from UVFlag or list of UVFlag objects to UVData or UVCal.
 
@@ -991,6 +991,11 @@ def flag_apply(uvf, uv, keep_existing=True, force_pol=False, history='',
     force_pol : bool, optional
         If True, will use 1 pol to broadcast to any other pol. If False, will
         require polarizations to match. Default is False.
+    time_atol : float, optional
+        Allowable time error in JD between times in uvf and times in uv to be
+        considered the same. Only used when uv is a UVData object or a UVFlag
+        object of baseline type and uvf is waterfall or antenna type. Default
+        value of 1e-8 corresponds to a bit under 1 ms.
     history : str, optional
         The history string to be added to uv.history. Default is empty string.
     return_net_flags : bool, optional
@@ -1037,8 +1042,8 @@ def flag_apply(uvf, uv, keep_existing=True, force_pol=False, history='',
         if uvf_i.type == 'waterfall':
             uvf_i = uvf_i.copy()  # don't change the input object
             if expected_type == 'baseline':
-                uvf_i.to_baseline(uv, force_pol=force_pol, run_check=run_check,
-                                  check_extra=check_extra,
+                uvf_i.to_baseline(uv, force_pol=force_pol, time_atol=time_atol,
+                                  run_check=run_check, check_extra=check_extra,
                                   run_check_acceptability=run_check_acceptability)
             else:
                 uvf_i.to_antenna(uv, force_pol=force_pol, run_check=run_check,

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -1975,15 +1975,16 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         raise ValueError("Must provide at least one of the following; ocalfits_files, acalfits_files, model_files, data_files")
 
     # recast strings as lists of strings
-    def _recast_as_list_if_str(to_cast):
-        if isinstance(to_cast, (str, np.string_)):
-            to_cast = [to_cast]
-        return to_cast
-    acalfits_files = _recast_as_list_if_str(acalfits_files)
-    ocalfits_files = _recast_as_list_if_str(ocalfits_files)
-    model_files = _recast_as_list_if_str(model_files)
-    data_files = _recast_as_list_if_str(data_files)
-    output_prefixes = _recast_as_list_if_str(output_prefixes)
+    if isinstance(acalfits_files, (str, np.string_)):
+        acalfits_files = [acalfits_files]
+    if isinstance(ocalfits_files, (str, np.string_)):
+        ocalfits_files = [ocalfits_files]
+    if isinstance(model_files, (str, np.string_)):
+        model_files = [model_files]
+    if isinstance(data_files, (str, np.string_)):
+        data_files = [data_files]
+    if isinstance(output_prefixes, (str, np.string_)):
+        output_prefixes = [output_prefixes]
 
     # ensure that an optional output prefix if no data file is provided.
     if output_prefixes is None:

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -2008,7 +2008,6 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
                             'a_priori_ants_only': a_priori_ants_only, 'use_cross_pol_vis': use_cross_pol_vis, 
                             'run_check': run_check, 'check_extra': check_extra, 'run_check_acceptability': run_check_acceptability}
         
-        
     # vdict stores all of the outputs (metrics, flags etc...) All possible products
     # are ultimately referenced by vdict but could be set to None. Outputs set to None are simply
     # not written and can be used to determine whether steps depending on them should be run.
@@ -2033,50 +2032,51 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
         rndnum = {True: '1', False: '2'}[median_round]
         alg = {True: 'detrend_medfilt', False: 'detrend_meanfilt'}[median_round]
         modified = {True: 'modified ', False: ''}[median_round]
+        start_flag_name = {True: 'uvf_apriori', False: 'uvf_init'}[median_round]
         final_flag_name = {True: 'uvf_init', False: 'uvf_combined2'}[median_round]
-        
+
         # Median/mean filter omnical gains and chi^2
         if omnical_filter:
-            (vdict['uvc_o'], vdict[f'uvf_og{rnd}'], vdict[f'uvf_ogf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg=alg, cal_mode='gain', metrics=metrics, flags=flags,
+            (vdict['uvc_o'], vdict[f'uvf_og{rnd}'], vdict[f'uvf_ogf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg=alg, cal_mode='gain', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=False, label=f'Omnical gains, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if omnical_chi2_filter:
-            (vdict['uvc_o'], vdict[f'uvf_ox{rnd}'], vdict[f'uvf_oxf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg=alg, cal_mode='tot_chisq', metrics=metrics, flags=flags, 
+            (vdict['uvc_o'], vdict[f'uvf_ox{rnd}'], vdict[f'uvf_oxf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg=alg, cal_mode='tot_chisq', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=False, label=f'Omnical chisq, {label} filter.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
         if omnical_zscore_filter:
-            (vdict['uvc_o'], vdict[f'uvf_oz{rnd}'], vdict[f'uvf_ozf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg='zscore_full_array', cal_mode=None, metrics=metrics, flags=flags,
+            (vdict['uvc_o'], vdict[f'uvf_oz{rnd}'], vdict[f'uvf_ozf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uvc_o'], uv_files=ocalfits_files, alg='zscore_full_array', cal_mode=None, metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=False, label=f'Omnical overall {modified}z-score of chisq.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
 
         # Median/mean filter abscal gains and chi^2
         if abscal_filter:
-            (vdict['uvc_a'], vdict[f'uvf_ag{rnd}'], vdict[f'uvf_agf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg=alg, cal_mode='gain', metrics=metrics, flags=flags,
+            (vdict['uvc_a'], vdict[f'uvf_ag{rnd}'], vdict[f'uvf_agf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg=alg, cal_mode='gain', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=False, label=f'Abscal gains, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if abscal_chi2_filter:
-            (vdict['uvc_a'], vdict[f'uvf_ax{rnd}'], vdict[f'uvf_axf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg=alg, cal_mode='tot_chisq', metrics=metrics, flags=flags, 
+            (vdict['uvc_a'], vdict[f'uvf_ax{rnd}'], vdict[f'uvf_axf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg=alg, cal_mode='tot_chisq', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=False, label=f'Abscal chisq, {label} filter.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
         if abscal_zscore_filter:
-            (vdict['uvc_a'], vdict[f'uvf_az{rnd}'], vdict[f'uvf_azf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg='zscore_full_array', cal_mode=None, metrics=metrics, flags=flags,
+            (vdict['uvc_a'], vdict[f'uvf_az{rnd}'], vdict[f'uvf_azf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uvc_a'], uv_files=acalfits_files, alg='zscore_full_array', cal_mode=None, metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=False, label=f'Abscal overall {modified}z-score of chisq.', apply_uvf_apriori=False, **xrfi_run_step_kwargs)
 
         # Median/mean filter omnical visibility solutions, cross-correlations, and autocorrelations
         if omnivis_filter:
-            (vdict['uv_v'], vdict[f'uvf_v{rnd}'], vdict[f'uvf_vf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uv_v'], uv_files=model_files, alg=alg,  dtype='uvdata', correlations='both', metrics=metrics, flags=flags,
+            (vdict['uv_v'], vdict[f'uvf_v{rnd}'], vdict[f'uvf_vf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uv_v'], uv_files=model_files, alg=alg,  dtype='uvdata', correlations='both', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=True, label=f'Omnical visibility solutions, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if cross_filter:
-            (vdict['uv_d'], vdict[f'uvf_d{rnd}'], vdict[f'uvf_df{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uv_d'], uv_files=data_files, alg=alg,  dtype='uvdata', correlations='cross', metrics=metrics, flags=flags,
+            (vdict['uv_d'], vdict[f'uvf_d{rnd}'], vdict[f'uvf_df{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uv_d'], uv_files=data_files, alg=alg,  dtype='uvdata', correlations='cross', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=True, label=f'Crosscorr, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
         if auto_filter:
-            (vdict['uv_d'], vdict[f'uvf_da{rnd}'], vdict[f'uvf_daf{rnd}'], vdict['uvf_apriori'], metrics, flags) = \
-                xrfi_run_step(uv=vdict['uv_d'], uv_files=data_files, alg=alg,  dtype='uvdata', correlations='auto', metrics=metrics, flags=flags,
+            (vdict['uv_d'], vdict[f'uvf_da{rnd}'], vdict[f'uvf_daf{rnd}'], vdict[start_flag_name], metrics, flags) = \
+                xrfi_run_step(uv=vdict['uv_d'], uv_files=data_files, alg=alg,  dtype='uvdata', correlations='auto', metrics=metrics, flags=flags, uvf_apriori=vdict[start_flag_name],
                               reinitialize=True, label=f'Autocorr, {label} filter.', apply_uvf_apriori=True, **xrfi_run_step_kwargs)
-            
+
         # Now that we've had a chance to load in all of the provided data products and run filters when specified, 
         # we combine the metrics computed so far into a combined metrics object, using the metrics list.
         if len(metrics) > 0:
@@ -2123,13 +2123,13 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     # settings for median round
     xrfi_run_step_kwargs['modified_z_score'] =  True 
     xrfi_run_step_kwargs['calculate_uvf_apriori'] = True
-    xrfi_run_step_kwargs['uvf_apriori'] = vdict['uvf_apriori']        
-            
+
     _run_all_filters(True, 
                      omnical_median_filter, omnical_chi2_median_filter, omnical_zscore_filter, 
                      abscal_median_filter, abscal_chi2_median_filter, abscal_zscore_filter,
                      omnivis_median_filter, cross_median_filter, auto_median_filter)
     spoof_init = (vdict['uvf_init'] is None)
+    median_round_flags_copy = copy.deepcopy(vdict['uvf_init'])
 
     ########################
     # RUN MEAN ROUND
@@ -2138,13 +2138,13 @@ def xrfi_run(ocalfits_files=None, acalfits_files=None, model_files=None,
     # settings for median round
     xrfi_run_step_kwargs['modified_z_score'] =  False 
     xrfi_run_step_kwargs['calculate_uvf_apriori'] = False
-    xrfi_run_step_kwargs['uvf_apriori'] = vdict['uvf_init']
 
     # Now perform the mean filtering after median filtering.
     _run_all_filters(False, 
                      omnical_mean_filter, omnical_chi2_mean_filter, omnical_zscore_filter, 
                      abscal_mean_filter, abscal_chi2_mean_filter, abscal_zscore_filter,
                      omnivis_mean_filter, cross_mean_filter, auto_mean_filter)
+    vdict['uvf_init'] = median_round_flags_copy  # prevents this from getting modified above
 
     ########################
     # WRITE EVERYTHING OUT


### PR DESCRIPTION
@ele-rath and I discovered that one major source of over-flagging in XRFI, as discussed in section 6 of http://reionization.org/manual_uploads/HERA097_H1C_IDR3_2_Memo.pdf, was a bug in XRFI where UVFlag objects created from UVCal objects could not be properly applied to UVData objects when the times were slightly mismatched (an issues we've encountered before).

In our tests, we see rounding errors cause certain integrations identified as bad during the median filter round of XRFI to not get flagged prior to the mean filter round because times were mismatched between the data files and calfits files. In the case of our tests on 2459122, the mismatch was at the ~40 microsecond level. This then led to very bright RFI skewing the statistics of the mean filter and creating edge-effects based on the size of the kernel.

This PR uses the new `time_atol` parameter in https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1133 to allow times that are close but not perfectly matching to get identified as the same. 

Here's a flagging pattern for a subset of that day before this fix:

![image](https://user-images.githubusercontent.com/5281139/151678536-bcb287fb-2deb-42a0-b7e1-deda5444e048.png)

And here's the same pattern after this fix:

![image](https://user-images.githubusercontent.com/5281139/151678548-d2e5a5be-4633-449f-826e-a7e9de876ba7.png)

This PR builds off #408 and requires approval of https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1133 in order for tests to pass.