### PR TITLE
Update how dependencies are specified in CI yaml

### DIFF
--- a/ci/hera_qm_tests.yml
+++ b/ci/hera_qm_tests.yml
@@ -15,5 +15,5 @@ dependencies:
   - scikit-learn # from hera_cal
   - scipy
   - pip:
-    - hera_cal
+    - hera-calibration
     - uvtools

--- a/ci/hera_qm_tests.yml
+++ b/ci/hera_qm_tests.yml
@@ -4,7 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - astropy>=3.2.3
-  - coveralls
   - h5py
   - matplotlib
   - numpy>=1.10

--- a/ci/hera_qm_tests.yml
+++ b/ci/hera_qm_tests.yml
@@ -3,17 +3,17 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - astropy>=3.2.3
+  - coveralls
+  - h5py
+  - matplotlib
   - numpy>=1.10
   - pip
-  - astropy>=3.2.3
-  - h5py
-  - scipy
   - pytest
-  - scikit-learn # from hera_cal
   - pytest-cov
-  - matplotlib
-  - coveralls
+  - pyuvdata
+  - scikit-learn # from hera_cal
+  - scipy
   - pip:
-    - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
-    - git+https://github.com/HERA-Team/uvtools
-    - git+https://github.com/HERA-Team/hera_cal
+    - hera_cal
+    - uvtools


### PR DESCRIPTION
Now that many of our dependencies are available on PyPI, we should not be using git links in the yaml we use for setting up CI environments.