### PR TITLE
Add `ant_class` module for classifying antennas based on absolute bounds for various metrics

### DIFF
--- a/hera_qm/__init__.py
+++ b/hera_qm/__init__.py
@@ -28,3 +28,4 @@ from . import auto_metrics  # noqa
 from . import firstcal_metrics  # noqa
 from . import omnical_metrics  # noqa 
 from . import metrics_io  # noqa
+from . import ant_class  # noqa

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -197,10 +197,10 @@ def antenna_bounds_checker(data, **kwargs):
     Example usage: antenna_bounds_checker(data, good=[(.5, 1)], suspect=[(0, .5), (1, 2)], bad=(-np.inf, np.inf))
     
     Arguments:
-        data: dictionary mapping ant-pol tuples (or autocorrelation keys) to 
+        data: dictionary mapping ant-pol tuples (or autocorrelation keys) to scalar values
         kwargs: named antenna classifications and the range or ranges of data values which map to those 
-            categories. Classification bounds are checked in order and the first accepted bound is used. 
-            All ranges are inclusive (i.e. >= or <=).
+            categories. Classification bounds are checked in order and the first accepted bound is used, 
+            though it is possible for antenna to not get classified. All ranges are inclusive (i.e. >= or <=).
         
     Returns:
         AntennaClassification object using data and bounds to classify antennas in data

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -47,3 +47,15 @@ class AntennaClassification():
         self._SUSPECT = 'suspect'
         self._BAD = 'bad'        
     
+    def __getitem__(self, key):
+        '''Get classification of a specific ant-pol tuple.'''
+        return self._classification[key]
+    
+    def __setitem__(self, key, value):
+        '''Set the classification of a specific ant-pol tuple.'''
+        self._classification[key] = value
+    
+    def __iter__(self):
+        '''Iterate over ant-pol tuples.'''
+        return iter(self._classification)
+    

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -59,3 +59,17 @@ class AntennaClassification():
         '''Iterate over ant-pol tuples.'''
         return iter(self._classification)
     
+    @property
+    def classes(self):
+        '''Sorted list of unique antenna classifications.'''
+        return sorted(set(self._classification.values()))
+
+    @property
+    def ants(self):
+        '''Sorted list of all classified ant-pol tuples.'''
+        return sorted(self._classification.keys())
+    
+    def get_all(self, classification):
+        '''Return all ant-pol tuples with the given classification.'''
+        return sorted([ant for ant, cls in self._classification.items() if cls == classification])
+   

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 def _check_antpol(ap):
-    '''Verifies that input is a valid ant-pol tuple. Otherwies, raises a ValueError'''
+    '''Verifies that input is a valid ant-pol tuple. Otherwise, raises a ValueError'''
     from hera_cal.utils import join_bl
     try:
         assert np.issubdtype(type(ap[0]), np.integer)

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -229,8 +229,8 @@ def antenna_bounds_checker(data, **kwargs):
             # iterate over (potentially disjoint) bounts in this 
             for bound in bounds:
                 if not _is_bound(bound):
-                    raise ValueError(f'Count not convert {bound} into a valid range for {cls} antennas.')
                 if (data[ant] >= bound[0]) and (data[ant] <= bound[1]):
+                    raise ValueError(f'Count not convert {bounds} into a valid range or ranges for {cls} antennas.')
                     classifiction_dict[cls].add(ant)
                     break
             if ant in classifiction_dict[cls]:

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -207,7 +207,7 @@ def antenna_bounds_checker(data, **kwargs):
     '''
     
     classifiction_dict = {cls: set([]) for cls in kwargs}
-    for ant in data:
+    for ant, val in data.items():
         # check that key is either a valid ant-pol tuple of an autocorrelation tuple
         try:
             _check_antpol(ant)
@@ -229,8 +229,8 @@ def antenna_bounds_checker(data, **kwargs):
             # iterate over (potentially disjoint) bounts in this 
             for bound in bounds:
                 if not _is_bound(bound):
-                if (data[ant] >= bound[0]) and (data[ant] <= bound[1]):
                     raise ValueError(f'Count not convert {bounds} into a valid range or ranges for {cls} antennas.')
+                if (val >= bound[0]) and (val <= bound[1]):
                     classifiction_dict[cls].add(ant)
                     break
             if ant in classifiction_dict[cls]:

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 the HERA Project
+# Licensed under the MIT License
+
+"""Class and algorithms to classify antennas by various data quality metrics."""
+import numpy as np
+
+
+def _check_antpol(ap):
+    '''Verifies that input is a valid ant-pol tuple. Otherwies, raises a ValueError'''
+    from hera_cal.utils import join_bl
+    try:
+        join_bl(ap, ap)
+    except:
+        raise ValueError(f"{ap} could not be interpreted as an antpol tuple of the form (1, 'Jee').")
+
+
+class AntennaClassification():
+    '''Object designed for storing a classification of antennas (expressed as ant-pol tuples), generally 
+    into good/suspect/bad categories,though it allows flexibility in what those are called and what other 
+    categories might be included. Enables easy getting and setting via brackets, as well the ability to 
+    combine classifications with the + operator in a way that means that an antenna marked as bad in either 
+    classification is bad and and that only an antenna marked as good in both classifications remains good.'''
+    
+    def __init__(self, **kwargs):
+        '''Create an AntennaClassification object using arbitrary classifications as keyword arguments. 
+        Antennas belonging to each classification are passed in as lists of ant-pol 2-tuples. For example,
+        ant_class = AntennaClassification(good=[(0, 'Jee'), (1, 'Jee')], whatever=[(0, 'Jnn'), (10, 'Jee')]).
+        Typical use is to pass in 'good', 'suspect', and/or 'bad' as kwargs, since these are the default
+        "quality_classes" which the object knows how to combine. Antennas must be uniquely classified.
+        
+        Arguments:
+            **kwargs: each is a list of ant-pol tuples with a classification given by the keyword argument
+        '''
+        self.clear()
+        for cls, antlist in kwargs.items():
+            for ant in antlist:
+                _check_antpol(ant)
+                if ant in self._classification:
+                    raise ValueError(f"Antenna {ant} cannot be clasified as {cls} because it is already classified as {self[ant]}")
+                self._classification[ant] = cls
+    
+    def clear(self):
+        '''Empties all classifications and resets default good/suspect/bad labels.'''
+        self._classification = {}
+        self._GOOD = 'good'
+        self._SUSPECT = 'suspect'
+        self._BAD = 'bad'        
+    

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -73,3 +73,30 @@ class AntennaClassification():
         '''Return all ant-pol tuples with the given classification.'''
         return sorted([ant for ant, cls in self._classification.items() if cls == classification])
    
+    @property
+    def good_ants(self):
+        '''Sorted list of ant-pol tuples with the current good classification (default "good").'''
+        return self.get_all(self._GOOD)     
+    
+    def is_good(self, ant):
+        '''Returns True if antenna has the current good classification (default "good").'''
+        return self[ant] == self._GOOD
+    
+    @property
+    def suspect_ants(self):
+        '''Sorted list of ant-pol tuples with the current suspect classification (default "suspect").'''
+        return self.get_all(self._SUSPECT)  
+
+    def is_suspect(self, ant):
+        '''Returns True if antenna has the current suspect classification (default "suspect").'''
+        return self[ant] == self._SUSPECT    
+    
+    @property
+    def bad_ants(self):
+        '''Sorted list of ant-pol tuples with the current bad classification (default "bad").'''
+        return self.get_all(self._BAD)
+        
+    def is_bad(self, ant):
+        '''Returns True if antenna has the current bad classification (default "bad").'''
+        return self[ant] == self._BAD
+        

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -62,22 +62,22 @@ class AntennaClassification():
     
     @property
     def classes(self):
-        '''Sorted list of unique antenna classifications.'''
-        return sorted(set(self._classification.values()))
+        '''Set of unique antenna classifications.'''
+        return set(self._classification.values())
 
     @property
     def ants(self):
-        '''Sorted list of all classified ant-pol tuples.'''
-        return sorted(self._classification.keys())
+        '''Set of all classified ant-pol tuples.'''
+        return set(self._classification.keys())
     
     def get_all(self, classification):
-        '''Return all ant-pol tuples with the given classification.'''
-        return sorted([ant for ant, cls in self._classification.items() if cls == classification])
+        '''Return set of all ant-pol tuples with the given classification.'''
+        return set([ant for ant, cls in self._classification.items() if cls == classification])
    
     @property
     def good_ants(self):
-        '''Sorted list of ant-pol tuples with the current good classification (default "good").'''
-        return self.get_all(self._GOOD)     
+        '''Set of ant-pol tuples with the current good classification (default "good").'''
+        return self.get_all(self._GOOD)
     
     def is_good(self, ant):
         '''Returns True if antenna has the current good classification (default "good").'''
@@ -85,7 +85,7 @@ class AntennaClassification():
     
     @property
     def suspect_ants(self):
-        '''Sorted list of ant-pol tuples with the current suspect classification (default "suspect").'''
+        '''Set of ant-pol tuples with the current suspect classification (default "suspect").'''
         return self.get_all(self._SUSPECT)  
 
     def is_suspect(self, ant):
@@ -94,7 +94,7 @@ class AntennaClassification():
     
     @property
     def bad_ants(self):
-        '''Sorted list of ant-pol tuples with the current bad classification (default "bad").'''
+        '''Set of ant-pol tuples with the current bad classification (default "bad").'''
         return self.get_all(self._BAD)
         
     def is_bad(self, ant):

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -100,3 +100,41 @@ class AntennaClassification():
         '''Returns True if antenna has the current bad classification (default "bad").'''
         return self[ant] == self._BAD
         
+    def define_quality(self, good='good', suspect='suspect', bad='bad'):
+        '''Resets the classifications considered good/suspect/bad. These are used for adding
+        together AntennaClassification objects.
+        
+        Arguments:
+            good: string to reset the classification considered good. Default "good".
+            suspect: string to reset the classification considered suspect. Default "suspect".
+            bad: string to reset the classification considered bad. Default "bad".
+        '''
+        self._GOOD = good
+        self._SUSPECT = suspect
+        self._BAD = bad
+    
+    @property
+    def quality_classes(self):
+        '''3-tuple of classification names considered good, suspect, and bad.'''
+        return self._GOOD, self._SUSPECT, self._BAD
+    
+    def to_quality(self, good_classes=[], suspect_classes=[], bad_classes=[]):
+        '''Function to reassigning classifications to good, suspect, or bad. All classifications
+        must have a mapping to one of those three, which are by default "good", "suspect", and "bad",
+        and can be queried by self.quality_classes and set by self.define_quality().
+        
+        Arguments:
+            good_classes: list of string classfications to be renamed to the current good classification
+            suspect_classes: list of string classfications to be renamed to the current suspect classification
+            bad_classes: list of string classfications to be renamed to the current bad classification            
+        '''        
+        # check to make sure all classes have been sorted into good, suspect, or bad
+        for cls in self.classes:
+            if cls not in self.quality_classes:
+                if (cls not in good_classes) and (cls not in suspect_classes) and (cls not in bad_classes):
+                    raise ValueError(f'Unable to convert "{cls}" to one of {self.quality_classes}.')
+        for new_class, old_classes in zip(self.quality_classes, [good_classes, suspect_classes, bad_classes]):
+            for ant, cls in self._classification.items():
+                if cls in old_classes:
+                    self._classification[ant] = new_class
+

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -99,7 +99,7 @@ class AntennaClassification():
         
     def is_bad(self, ant):
         '''Returns True if antenna has the current bad classification (default "bad"), else False.'''
-        (ant in self._classification) and (self[ant] == self._BAD)
+        return (ant in self._classification) and (self[ant] == self._BAD)
         
     def define_quality(self, good='good', suspect='suspect', bad='bad'):
         '''Resets the classifications considered good/suspect/bad. These are used for adding

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -10,6 +10,7 @@ def _check_antpol(ap):
     '''Verifies that input is a valid ant-pol tuple. Otherwies, raises a ValueError'''
     from hera_cal.utils import join_bl
     try:
+        assert np.issubdtype(type(ap[0]), np.integer)
         join_bl(ap, ap)
     except:
         raise ValueError(f"{ap} could not be interpreted as an antpol tuple of the form (1, 'Jee').")
@@ -45,7 +46,7 @@ class AntennaClassification():
         self._classification = {}
         self._GOOD = 'good'
         self._SUSPECT = 'suspect'
-        self._BAD = 'bad'        
+        self._BAD = 'bad'
     
     def __getitem__(self, key):
         '''Get classification of a specific ant-pol tuple.'''

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -80,8 +80,8 @@ class AntennaClassification():
         return self.get_all(self._GOOD)
     
     def is_good(self, ant):
-        '''Returns True if antenna has the current good classification (default "good").'''
-        return self[ant] == self._GOOD
+        '''Returns True if antenna has the current good classification (default "good"), else False.'''
+        return (ant in self._classification) and (self[ant] == self._GOOD)
     
     @property
     def suspect_ants(self):
@@ -89,8 +89,8 @@ class AntennaClassification():
         return self.get_all(self._SUSPECT)  
 
     def is_suspect(self, ant):
-        '''Returns True if antenna has the current suspect classification (default "suspect").'''
-        return self[ant] == self._SUSPECT    
+        '''Returns True if antenna has the current suspect classification (default "suspect"), else False.'''
+        return (ant in self._classification) and (self[ant] == self._SUSPECT)
     
     @property
     def bad_ants(self):
@@ -98,8 +98,8 @@ class AntennaClassification():
         return self.get_all(self._BAD)
         
     def is_bad(self, ant):
-        '''Returns True if antenna has the current bad classification (default "bad").'''
-        return self[ant] == self._BAD
+        '''Returns True if antenna has the current bad classification (default "bad"), else False.'''
+        (ant in self._classification) and (self[ant] == self._BAD)
         
     def define_quality(self, good='good', suspect='suspect', bad='bad'):
         '''Resets the classifications considered good/suspect/bad. These are used for adding

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -143,7 +143,7 @@ def test_is_bound():
 def test_antenna_bounds_checker():
     data = {(1, 'Jee'): 1, (2, 'Jee'): 3, (3, 'Jee'): 4, (4, 4, 'ee'): 10}
 
-    ac = ant_class.antenna_bounds_checker(data, good=[(0, 2), (3.5, 4)], weird=[(4, np.inf)])
+    ac = ant_class.antenna_bounds_checker(data, good=[(0, 2), (3.5, 4)], weird=(4, np.inf))
     ac.define_quality(bad='weird')
     assert (1, 'Jee') in ac.good_ants
     assert (3, 'Jee') in ac.good_ants
@@ -156,3 +156,4 @@ def test_antenna_bounds_checker():
         ac = ant_class.antenna_bounds_checker(data, bad_bound=[(0, -1)])
         ac = ant_class.antenna_bounds_checker(data, bad_bound=(0, -1))
         ac = ant_class.antenna_bounds_checker({(1, 2, 'ee'): 1.0}, bad_bound=[(0, -1)])
+        ac = ant_class.antenna_bounds_checker({(1, 2, 'ee'): 1.0}, bound=[(0, 1)])

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -127,3 +127,16 @@ def test_AntennaClassification_add():
     # test bad + bad
     assert ac.is_bad((1,'Jee'))
 
+
+def test_is_bound():
+    assert ant_class._is_bound([0, 1])
+    assert ant_class._is_bound(np.array([0, 1]))
+    assert ant_class._is_bound((0, 1))
+    assert ant_class._is_bound([0, 1.0])
+
+    assert not ant_class._is_bound([2, 1, 3])
+    assert not ant_class._is_bound([2, 1])
+    assert not ant_class._is_bound([1, 'stuff'])
+    assert not ant_class._is_bound([1, 1 + 1j])
+
+

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 the HERA Project
+# Licensed under the MIT License
+"""Tests for the antenna_metrics module."""
+
+import pytest
+import numpy as np
+from hera_qm import ant_class
+
+
+def test_check_antpol():
+    ant_class._check_antpol((1, 'Jnn'))
+    ant_class._check_antpol((1, 'ee'))
+    ant_class._check_antpol((1, 'x'))
+    with pytest.raises(ValueError):
+        ant_class._check_antpol((1.0, 'Jee'))
+    with pytest.raises(ValueError):
+        ant_class._check_antpol((1, 'not a pol'))
+    with pytest.raises(ValueError):
+        ant_class._check_antpol((1, 1, 'Jee'))
+

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -85,3 +85,45 @@ def test_AntennaClassification():
     assert len(ac.ants) == 0
 
 
+def test_AntennaClassification_add():
+    ac1 = ant_class.AntennaClassification(good=[(0, 'Jnn'), (0, 'Jee'), (1, 'Jnn')],
+                                      bad=[(1,'Jee')], 
+                                      weird=[(2, 'Jee'), (2, 'Jnn')])
+    ac2 = ant_class.AntennaClassification(good=[(0, 'Jnn')],
+                                          bad=[(1,'Jee'), (0, 'Jee'), (2, 'Jee')], 
+                                          weird=[(1, 'Jnn'), (2, 'Jnn')])
+    # test wrong type error
+    with pytest.raises(TypeError):
+        ac1 += 1
+
+    # test non-quality class error
+    with pytest.raises(ValueError):
+        ac = ac1 + ac2
+
+    ac1.define_quality(suspect='weird')
+
+    # test quality class mismatch error
+    with pytest.raises(ValueError):
+        ac = ac1 + ac2
+
+    ac2.define_quality(suspect='weird')
+    ac = ac1 + ac2
+
+    # test good + good
+    assert ac.is_good((0, 'Jnn'))
+
+    # test good + bad
+    assert ac.is_bad((0, 'Jee'))
+
+    # test good + suspect
+    assert ac.is_suspect((1, 'Jnn'))
+
+    # test suspect + suspect
+    assert ac.is_suspect((2, 'Jnn'))
+
+    # test suspect + bad
+    assert ac.is_bad((2, 'Jee'))
+
+    # test bad + bad
+    assert ac.is_bad((1,'Jee'))
+

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -140,3 +140,19 @@ def test_is_bound():
     assert not ant_class._is_bound([1, 1 + 1j])
 
 
+def test_antenna_bounds_checker():
+    data = {(1, 'Jee'): 1, (2, 'Jee'): 3, (3, 'Jee'): 4, (4, 4, 'ee'): 10}
+
+    ac = ant_class.antenna_bounds_checker(data, good=[(0, 2), (3.5, 4)], weird=[(4, np.inf)])
+    ac.define_quality(bad='weird')
+    assert (1, 'Jee') in ac.good_ants
+    assert (3, 'Jee') in ac.good_ants
+    assert (3, 'Jee') not in ac.bad_ants
+    assert (4, 'Jee') in ac.bad_ants
+    assert (4, 4, 'ee') not in ac
+    assert (2, 'Jee') not in ac
+
+    with pytest.raises(ValueError):
+        ac = ant_class.antenna_bounds_checker(data, bad_bound=[(0, -1)])
+        ac = ant_class.antenna_bounds_checker(data, bad_bound=(0, -1))
+        ac = ant_class.antenna_bounds_checker({(1, 2, 'ee'): 1.0}, bad_bound=[(0, -1)])

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -19,3 +19,69 @@ def test_check_antpol():
     with pytest.raises(ValueError):
         ant_class._check_antpol((1, 1, 'Jee'))
 
+
+def test_AntennaClassification():
+    # test that that doubled antenna raises error
+    with pytest.raises(ValueError):
+        ant_class.AntennaClassification(good=[(1, 'Jee')], bad=[(1, 'Jee')])
+            
+    ac = ant_class.AntennaClassification(good=[(0, 'Jnn'), (0, 'Jee')],
+                                         bad=[(1,'Jee'), (1, 'Jnn')], 
+                                         suspect=[(2, 'Jee')],
+                                         weird=[(2, 'Jnn')])  
+
+    # test getter
+    assert ac[(0, 'Jnn')] == 'good'
+    assert ac[(2, 'Jnn')] == 'weird'
+
+    # test setter
+    ac[(2, 'Jee')] = 'strange'
+    assert ac[(2, 'Jee')] == 'strange'
+    ac[(2, 'Jee')] = 'suspect'
+
+    # test iter
+    assert (0, 'Jnn') in ac
+    assert len(list(ac.__iter__())) == 6
+
+    # test classes
+    assert ac.classes == set(['good', 'bad', 'suspect', 'weird'])
+
+    # test ants
+    assert set(ac.ants) == set([(0, 'Jee'), (0, 'Jnn'),
+                                (1, 'Jee'), (1, 'Jnn'),
+                                (2, 'Jee'), (2, 'Jnn')])
+
+    # test get_all
+    assert ac.get_all('weird') == set([(2, 'Jnn')])
+
+    # test good_ants, suspect_ants, bad_ants
+    assert ac.good_ants == set([(0, 'Jee'), (0, 'Jnn')])
+    assert ac.suspect_ants == set([(2, 'Jee')])
+    assert ac.bad_ants == set([(1, 'Jee'), (1, 'Jnn')])
+
+    # test is_good, is_bad, is_suspect
+    assert ac.is_good((0, 'Jee'))
+    assert not ac.is_good((1, 'Jee'))
+    assert ac.is_bad((1, 'Jee'))
+    assert not ac.is_bad((2, 'Jee'))
+    assert ac.is_suspect((2, 'Jee'))
+    assert not ac.is_suspect((3, 'Jee'))
+
+    # test quality_classes, define_quality, to_quality
+    assert ac.quality_classes == ('good', 'suspect', 'bad')
+    ac.define_quality(suspect='weird')
+    assert ac.is_suspect((2, 'Jnn'))
+    assert not ac.is_suspect((2, 'Jee'))
+
+    with pytest.raises(ValueError):
+        ac.to_quality()
+    ac.to_quality(suspect_classes=['suspect', 'weird'])
+                
+    # test clear
+    ac.define_quality(good='lep', suspect='korf', bad='pillot')
+    ac.clear()
+    assert ac.quality_classes == ('good', 'suspect', 'bad')
+    assert len(ac.classes) == 0
+    assert len(ac.ants) == 0
+
+


### PR DESCRIPTION
This PR adds a new module `ant_class` and the `AntennaClassification` object, which allows for the flexible categorization of ant-pol tuples. 

It is initialized like `AntennaClassification(good=[(0, 'Jee'), (1, 'Jee')], whatever=[(0, 'Jnn'), (10, 'Jee')])` and takes arbitrary categorizations. Allows setting and getting of a specific antenna's classification using `[]`, as well as `.ants` and `.classes` properties and a `.get_all(classification)` function.

However, there are three special "quality" classifications (by default `"good"`, `"suspect"`, and `"bad"`, but they can be modified) that are queried via the property e.g. `.good_ants` or the function `.is_good(ant).` Furthermore, these classifications the sensible enable combination of `AntennaClassification` objects by overloading `+` such that good + good = good, good + bad = bad, good + suspect = suspect, bad + suspect = bad, and bad + bad = bad.

This PR adds also a new function `antenna_bounds_checker()` to `ant_class` designed for turning scalar antenna metrics into `AntennaClassification` objects. This function is very general and I plan to add absolute limits checkers built on top of it.

This PR lays the groundwork for future absolute limits checking. Eventually, the goal here is to implement new absolute limit checking on antenna power, bandpass slope, etc. as has been prototyped by @AaronParsons in https://github.com/HERA-Team/hera_notebook_templates/blob/ef53071cfac322a6fe9d629d0ed508028bd1fe3c/notebooks/fastcal_inspect.ipynb