### PR TITLE
Ant metrics fast reader

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -202,10 +202,10 @@ class AntennaMetrics():
 
         Attributes
         ----------
-        hd_sum : HERAData
-            HERAData object generated from sum_files.
-        hd_diff : HERAData
-            HERAData object generated from diff_files.
+        hd_sum : HERADataFastReader
+            HERADataFastReader object generated from sum_files.
+        hd_diff : HERADataFastReader
+            HERADataFastReader object generated from diff_files.
         ants : list of tuples
             List of antenna-polarization tuples to assess
         antnums : list of ints
@@ -213,7 +213,7 @@ class AntennaMetrics():
         antpols : List of str
             List of antenna polarization strings. Typically ['Jee', 'Jnn']
         bls : list of ints
-            List of baselines in HERAData object.
+            List of baselines in HERADataFastReader object.
         datafile_list_sum : list of str
             List of sum data filenames that went into this calculation.
         datafile_list_diff : list of str
@@ -228,10 +228,10 @@ class AntennaMetrics():
 
         """
         
-        from hera_cal.io import HERAData
+        from hera_cal.io import HERADataFastReader
         from hera_cal.utils import split_bl, comply_pol, split_pol, join_pol
         # prevents the need for importing again later
-        self.HERAData = HERAData
+        self.HERADataFastReader = HERADataFastReader
         self.split_bl = split_bl
         self.join_pol = join_pol
         self.split_pol = split_pol
@@ -244,17 +244,13 @@ class AntennaMetrics():
         if (diff_files is not None) and (len(diff_files) != len(sum_files)):
             raise ValueError(f'The number of sum files ({len(sum_files)}) does not match the number of diff files ({len(diff_files)}).')
         self.datafile_list_sum = sum_files
-        self.hd_sum = HERAData(sum_files)
+        self.hd_sum = HERADataFastReader(sum_files)
         if diff_files is None or len(diff_files) == 0:
             self.datafile_list_diff = None
             self.hd_diff = None
         else:
             self.datafile_list_diff = diff_files
-            self.hd_diff = HERAData(diff_files)
-        if len(self.hd_sum.filepaths) > 1:
-            # only load baselines in all files
-            self.bls = sorted(set.intersection(*[set(bls) for bls in self.hd_sum.bls.values()]))
-        else:
+            self.hd_diff = HERADataFastReader(diff_files)
             self.bls = self.hd_sum.bls
 
         # Figure out polarizations in the data

--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -285,7 +285,7 @@ class AntennaMetrics():
         self.same_pols = [pol for pol in self.pols if split_pol(pol)[0] == split_pol(pol)[1]]
 
         # Figure out which antennas are in the data
-        self.ants = sorted(sorted(set([ant for bl in self.bls for ant in split_bl(bl)])))
+        self.ants = sorted(set([ant for bl in self.bls for ant in split_bl(bl)]))
         self.antnums = sorted(set([ant[0] for ant in self.ants]))
         self.antpols = sorted(set([ant[1] for ant in self.ants]))
         self.ants_per_antpol = {antpol: sorted([ant for ant in self.ants if ant[1] == antpol]) for antpol in self.antpols}

--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -200,16 +200,16 @@ class AntennaMetrics():
         freq_alg : function, optional
             Averaging function along the frequency axis for producing correlation stats.
             See calc_corr_stats() for more details.
-        sum_data : dictionary or DataContainer, optional
+        sum_data : hera_cal DataContainer, optional
             Use this data instead of loading data form sum_files (which is used only for metadata).
             This option is indended for interactive use when the data are already in memory.
             Must include the full data set expected from sum_files. Nfiles_per_load and
             Nbls_per_load must both be None if this is provided.
-        diff_data : dictionary or DataContainer, optional
+        diff_data : hera_cal DataContainer, optional
             Same as sum_data, but for the diff files.
-        sum_flags : dictionary or DataContainer, optional
+        sum_flags : hera_cal DataContainer, optional
             Same as sum_data, but for flags instead of data
-        diff_flags : dictionary or DataContainer, optional
+        diff_flags : hera_cal DataContainer, optional
             Same as sum_flags, but for the diff files.
 
         Attributes

--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -257,13 +257,13 @@ class AntennaMetrics():
             raise ValueError(f'The number of sum files ({len(sum_files)}) does not match the number of diff files ({len(diff_files)}).')
         self.datafile_list_sum = sum_files
         self.hd_sum = HERADataFastReader(sum_files)
+        self.bls = self.hd_sum.bls
         if diff_files is None or len(diff_files) == 0:
             self.datafile_list_diff = None
             self.hd_diff = None
         else:
             self.datafile_list_diff = diff_files
             self.hd_diff = HERADataFastReader(diff_files)
-            self.bls = self.hd_sum.bls
 
         # save sum_data, etc. internally. Typically these are None.
         self.sum_data = sum_data

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -326,10 +326,10 @@ def test_ant_metrics_run_and_load_antenna_metrics():
 
     # test a priori flagging via YAML
     four_pol_uvh5 = DATA_PATH + '/zen.2457698.40355.full_pol_test.uvh5'
-    apf_yaml = os.path.join(DATA_PATH, 'a_priori_flags_old_pols.yaml')
+    apf_yaml = os.path.join(DATA_PATH, 'a_priori_flags_sample.yaml')
     am = ant_metrics.ant_metrics_run(four_pol_uvh5, diff_files=four_pol_uvh5, overwrite=True, a_priori_xants_yaml=apf_yaml, verbose=True)
     am_hdf5 = ant_metrics.load_antenna_metrics(four_pol_uvh5.replace('.uvh5', '.ant_metrics.hdf5'))
-    for ant in [(0, 'Jxx'), (0, 'Jyy'), (10, 'Jxx'), (10, 'Jyy'), (1, 'Jxx'), (3, 'Jyy')]:
+    for ant in [(0, 'Jee'), (0, 'Jnn'), (10, 'Jee'), (10, 'Jnn'), (1, 'Jee'), (3, 'Jnn')]:
         assert ant in am_hdf5['xants']
         assert am_hdf5['removal_iteration'][ant] == -1
 


### PR DESCRIPTION
This PR migrates `ant_metrics` over to using the new `HERADataFastReader`, which should improve I/O by a factor of 2 or better.

This PR also gives advanced users the option of using the `AntennaMetrics` class with only minimal I/O by providing `DataContainer`s directly. This should be useful for interactive work, like the fastcal inspect notebook currently being developed: https://github.com/HERA-Team/hera_notebook_templates/blob/master/notebooks/fastcal_inspect.ipynb