### PR TITLE
Autocorrelation Power and Slope Classifiers

### DIFF
--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -100,7 +100,7 @@ class AntennaClassification():
     def is_bad(self, ant):
         '''Returns True if antenna has the current bad classification (default "bad"), else False.'''
         return (ant in self._classification) and (self[ant] == self._BAD)
-        
+
     def define_quality(self, good='good', suspect='suspect', bad='bad'):
         '''Resets the classifications considered good/suspect/bad. These are used for adding
         together AntennaClassification objects.
@@ -180,6 +180,20 @@ class AntennaClassification():
         ac = AntennaClassification(**{qual: [ant for ant in new_class if new_class[ant] == qual] for qual in self.quality_classes})
         ac.define_quality(*self.quality_classes)
         return ac
+
+    def __str__(self):
+        outstr = ''
+        to_show = [cls for cls in self.quality_classes if cls in self.classes]
+        to_show += [cls for cls in self.classes if cls not in self.quality_classes]
+        pols = sorted(set([ant[1] for ant in self.ants]))
+        for pol in pols:
+            outstr += f'{pol}:\n----------\n'
+            for cls in to_show:
+                ants = sorted([ant for ant in self.get_all(cls) if ant[1] == pol])
+                outstr += f'{cls} ({len(ants)} antpols):\n' + ', '.join([str(ant[0]) for ant in ants]) + '\n\n'
+            outstr += '\n'
+
+        return outstr.rstrip('\n')
 
 
 def _is_bound(bound):

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -5,6 +5,7 @@
 """Class and algorithms to classify antennas by various data quality metrics."""
 import numpy as np
 from scipy.ndimage import median_filter
+import warnings
 
 
 def _check_antpol(ap):
@@ -313,7 +314,9 @@ def auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=100, fi
         mean_data = np.mean(data[bl], axis=0)
         med_filt = median_filter(mean_data, size=filt_size)[edge_cut:-edge_cut]
         fit = np.polyfit(np.linspace(-.5, .5, len(mean_data))[edge_cut:-edge_cut], med_filt, 1)
-        relative_slopes[bl] = (fit[0] / fit[1] if np.isfinite(fit[1]) else np.sign(fit[0]) * np.inf)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="invalid value encountered")
+            relative_slopes[bl] = (fit[0] / fit[1] if np.isfinite(fit[1]) else np.sign(fit[0]) * np.inf)
 
     return antenna_bounds_checker(relative_slopes, good=good, suspect=suspect, bad=(-np.inf, np.inf))
 

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -6,6 +6,8 @@
 import pytest
 import numpy as np
 from hera_qm import ant_class
+from hera_cal import io
+from hera_qm.data import DATA_PATH
 
 
 def test_check_antpol():
@@ -163,3 +165,19 @@ def test_antenna_bounds_checker():
         ac = ant_class.antenna_bounds_checker(data, bad_bound=(0, -1))
         ac = ant_class.antenna_bounds_checker({(1, 2, 'ee'): 1.0}, bad_bound=[(0, -1)])
         ac = ant_class.antenna_bounds_checker({(1, 2, 'ee'): 1.0}, bound=[(0, 1)])
+
+
+def test_auto_power_checker():
+    hd = io.HERADataFastReader(DATA_PATH + '/zen.2459122.49827.sum.downselected.uvh5')
+    data, _, _ = hd.read(read_flags=False, read_nsamples=False)
+    auto_power_class = ant_class.auto_power_checker(data, good=(2,30), suspect=(1,80))
+
+    for ant in {(36, 'Jee'), (36, 'Jnn'), (51, 'Jnn'), (83, 'Jee'), (83, 'Jnn'), (87, 'Jee'), (98, 'Jee'), (98, 'Jnn'), (117, 'Jnn'), (135, 'Jnn'), (160, 'Jee')}:
+        assert ant in auto_power_class.good_ants
+    
+    for ant in {(51, 'Jee'), (53, 'Jee'), (53, 'Jnn'), (85, 'Jee'), (85, 'Jnn'), (87, 'Jnn'), (117, 'Jee'), (157, 'Jee'), (157, 'Jnn'), (160, 'Jnn')}:
+        assert ant in auto_power_class.suspect_ants
+    
+    for ant in {(65, 'Jee'), (65, 'Jnn'), (68, 'Jee'), (68, 'Jnn'), (93, 'Jee'), (93, 'Jnn'), (116, 'Jee'), (116, 'Jnn'), (135, 'Jee')}:
+        assert ant in auto_power_class.bad_ants
+

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -181,3 +181,19 @@ def test_auto_power_checker():
     for ant in {(65, 'Jee'), (65, 'Jnn'), (68, 'Jee'), (68, 'Jnn'), (93, 'Jee'), (93, 'Jnn'), (116, 'Jee'), (116, 'Jnn'), (135, 'Jee')}:
         assert ant in auto_power_class.bad_ants
 
+
+def test_auto_slope_checker():
+    hd = io.HERADataFastReader(DATA_PATH + '/zen.2459122.49827.sum.downselected.uvh5')
+    data, _, _ = hd.read(read_flags=False, read_nsamples=False)
+    auto_slope_class = ant_class.auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=20)  # smaller edge cut due to downsampling
+
+    for ant in {(83, 'Jee'), (160, 'Jee'), (85, 'Jee'), (98, 'Jee'), (83, 'Jnn'), (160, 'Jnn'), (85, 'Jnn'), (98, 'Jnn'), (36, 'Jee'), (135, 'Jee'), (157, 'Jee'),
+                (51, 'Jee'), (87, 'Jnn'), (36, 'Jnn'), (135, 'Jnn'), (157, 'Jnn'), (117, 'Jee'), (53, 'Jee'), (51, 'Jnn'), (117, 'Jnn'), (53, 'Jnn')}:
+        assert ant in auto_slope_class.good_ants
+    
+    for ant in {(68, 'Jee'), (87, 'Jee'), (68, 'Jnn')}:
+        assert ant in auto_slope_class.suspect_ants
+    
+    for ant in {(65, 'Jnn'), (116, 'Jee'), (93, 'Jnn'), (65, 'Jee'), (93, 'Jee'), (116, 'Jnn')}:
+        assert ant in auto_slope_class.bad_ants
+

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -30,6 +30,12 @@ def test_AntennaClassification():
                                          suspect=[(2, 'Jee')],
                                          weird=[(2, 'Jnn')])  
 
+    # test string
+    assert 'good' in str(ac)
+    assert 'suspect' in str(ac).split('good')[1]
+    assert 'bad' in str(ac).split('suspect')[1]
+    assert 'weird' in str(ac).split('bad')[1]
+
     # test getter
     assert ac[(0, 'Jnn')] == 'good'
     assert ac[(2, 'Jnn')] == 'weird'


### PR DESCRIPTION
This PR implements bounds checking from @AaronParsons's fastcal notebook: https://github.com/HERA-Team/hera_notebook_templates/blob/ef53071cfac322a6fe9d629d0ed508028bd1fe3c/notebooks/fastcal_inspect.ipynb

It adds functions that turn autocorrelation datacontainers into `AntennaClassification` objects based on power (in correlator units) or relative slope over the band. 