### PR TITLE
Add functions for flagging auto-correlations

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - scikit-learn # from hera_cal
   - pytest-cov
   - pyyaml
+  - hera-filters
   - pip:
     - git+https://github.com/HERA-Team/uvtools
     - git+https://github.com/HERA-Team/hera_cal

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -321,9 +321,9 @@ def auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=100, fi
 
     return antenna_bounds_checker(relative_slopes, good=good, suspect=suspect, bad=(-np.inf, np.inf))
 
-def auto_rfi_checker(data, good=(0, 0.1), suspect=(0.1, 0.2), nsig=6, antenna_class=None, flag_threshold=0.1, 
-                     kernel_widths=[3, 4, 5], mode='dpss_matrix', filter_centers=[0, -2700e-9, 2700e-9],
-                     filter_half_widths=[200e-9, 200e-9, 200e-9], eigenval_cutoff=[1e-9]):
+def auto_rfi_checker(data, good=(0, 0.1), suspect=(0.1, 0.2), nsig=6, antenna_class=None, flag_broadcast_thresh=0.1, 
+                     kernel_widths=[3, 4, 5], mode='dpss_matrix', filter_centers=[0],
+                     filter_half_widths=[200e-9], eigenval_cutoff=[1e-9]):
     """
     Classifies ant-pols as good, suspect, or bad based on the fraction of channels flagged.
     Flagging takes place in two steps: (1) "channel_diff_flagger" is used to 
@@ -340,18 +340,18 @@ def auto_rfi_checker(data, good=(0, 0.1), suspect=(0.1, 0.2), nsig=6, antenna_cl
         antenna_class: AntennaClassification, default=None
             Optional AntennaClassification object. If provided, the flagging method chosen will skip antennas marked "bad".
             Used in both steps
-        flag_threshold: float, default=0.1
+        flag_broadcast_thresh: float, default=0.1
             The fraction of flags required to trigger a broadcast across all auto-correlations for
             a given (time, frequency) pixel in the combined flag array. Used in both steps
         kernel_widths: list
             Half-width of the convolution kernels used to produce model. True kernel width is (2 * kernel_width + 1)
             Only used in the "channel_diff_flagger" step
-        mode: str, default='dpss_solve'
+        mode: str, default='dpss_matrix'
             Method used to solve for DPSS model components. Options are 'dpss_matrix', 'dpss_solve', and 'dpss_leastsq'.
             Only used in "dpss_flagger" step
-        filter_centers: array-like
+        filter_centers: array-like, default=[0]
             list of floats of centers of delay filter windows in nanosec. Only used in "dpss_flagger"
-        filter_half_widths: array-like
+        filter_half_widths: array-like, default=[200e-9]
             list of floats of half-widths of delay filter windows in nanosec. Only used in "dpss_flagger"
         
     Returns:
@@ -360,7 +360,7 @@ def auto_rfi_checker(data, good=(0, 0.1), suspect=(0.1, 0.2), nsig=6, antenna_cl
     """
     # Flag using convolution kernels
     antenna_flags, array_flags = xrfi.flag_autos(data, flag_method="channel_diff_flagger", nsig=nsig, antenna_class=antenna_class,
-                                     flag_threshold=flag_threshold, kernel_widths=kernel_widths)
+                                     flag_broadcast_thresh=flag_broadcast_thresh, kernel_widths=kernel_widths)
 
     # Override antenna flags with array-wide flags for next step
     for key in antenna_flags.keys():

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -5,6 +5,7 @@
 """Class and algorithms to classify antennas by various data quality metrics."""
 import numpy as np
 from scipy.ndimage import median_filter
+import warnings
 
 
 def _check_antpol(ap):
@@ -313,7 +314,9 @@ def auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=100, fi
         mean_data = np.mean(data[bl], axis=0)
         med_filt = median_filter(mean_data, size=filt_size)[edge_cut:-edge_cut]
         fit = np.polyfit(np.linspace(-.5, .5, len(mean_data))[edge_cut:-edge_cut], med_filt, 1)
-        relative_slopes[bl] = (fit[0] / fit[1] if np.isfinite(fit[1]) else np.sign(fit[0]) * np.inf)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="invalid value encountered")
+            relative_slopes[bl] = (fit[0] / fit[1] if np.isfinite(fit[1]) else np.sign(fit[0]) * np.inf)
 
     return antenna_bounds_checker(relative_slopes, good=good, suspect=suspect, bad=(-np.inf, np.inf))
 

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -216,7 +216,8 @@ def test_auto_rfi_checker():
     data[(83, 83, 'ee')][:, idx] *= 1.2 # Suspect auto
 
     # Run RFI checker
-    auto_rfi_class = ant_class.auto_rfi_checker(data, antenna_class=auto_class, kernel_widths=[1, 2])
+    auto_rfi_class = ant_class.auto_rfi_checker(data, antenna_class=auto_class, kernel_widths=[1, 2], filter_centers=[0, 2700e-9, -2700e-9],
+                                                filter_half_widths=[200e-9, 200e-9, 200e-9])
     assert (36, 'Jee') in auto_rfi_class.bad_ants
     assert (83, 'Jee') in auto_rfi_class.suspect_ants
 

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -197,3 +197,34 @@ def test_auto_slope_checker():
     for ant in {(65, 'Jnn'), (116, 'Jee'), (93, 'Jnn'), (65, 'Jee'), (93, 'Jee'), (116, 'Jnn')}:
         assert ant in auto_slope_class.bad_ants
 
+def test_auto_rfi_checker():
+    hd = io.HERADataFastReader(DATA_PATH + '/zen.2459122.49827.sum.downselected.uvh5')
+    data, _, _ = hd.read(read_flags=False, read_nsamples=False)
+
+    # Get bad antennas
+    auto_power_class = ant_class.auto_power_checker(data, good=(2, 30), suspect=(1, 80))
+    auto_slope_class = ant_class.auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=20)  # smaller edge cut due to downsampling
+    auto_class = auto_power_class + auto_slope_class
+
+    # Modify metadata to compensate for down-selection
+    data.times /= 5
+
+    # Artificially add RFI to autos
+    idx = np.arange(0, data.freqs.shape[0], 10)
+    data[(36, 36, 'ee')][:, idx] *= 1.2 # Bad auto
+    idx = np.arange(0, data.freqs.shape[0], 30)
+    data[(83, 83, 'ee')][:, idx] *= 1.2 # Suspect auto
+
+    # Run RFI checker
+    auto_rfi_class = ant_class.auto_rfi_checker(data, antenna_class=auto_class, kernel_widths=[1, 2])
+    assert (36, 'Jee') in auto_rfi_class.bad_ants
+    assert (83, 'Jee') in auto_rfi_class.suspect_ants
+
+    # Make sure antennas that were previously marked bad are still marked bad
+    for ant in auto_class.bad_ants:
+        assert ant in auto_rfi_class.bad_ants
+    
+    # Show that all other antennas are marked "good"
+    for ant in auto_class.ants:
+        if ant not in [(36, 'Jee'), (83, 'Jee')] and ant not in auto_class.bad_ants:
+            assert ant in auto_rfi_class.good_ants

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -198,7 +198,7 @@ def test_robus_divide():
     c = xrfi.robust_divide(a, b)
     assert np.array_equal(c, np.array([1. / 2., np.inf, np.inf]))
 
-def test_dpss_flagger():
+def test_detrend_dpss_filt():
     freqs = np.linspace(50e6, 250e6, 500)
     df = np.diff(freqs)[0]
     dt = 10
@@ -217,30 +217,24 @@ def test_dpss_flagger():
     noise = np.abs(data) / np.sqrt(intcnt / 2)
     
     # Identify RFI
-    wgts = xrfi.dpss_flagger(
+    wgts = xrfi.detrend_dpss_filt(
         data, freqs=freqs, filter_centers=[0], filter_half_widths=[50e-9], noise=noise,
     )
     assert np.allclose(~wgts.astype(bool), mask)
     
-    # Identify RFI w/ modified z-score
-    wgts = xrfi.dpss_flagger(
-        data, freqs=freqs, filter_centers=[0], filter_half_widths=[50e-9],
-    )
-    assert np.allclose(~wgts.astype(bool), mask)
-    
     # Identify RFI w/ weights grid provided
-    wgts = xrfi.dpss_flagger(
-        data, freqs=freqs, filter_centers=[0], filter_half_widths=[50e-9], wgts=(~mask).astype(float)
+    wgts = xrfi.detrend_dpss_filt(
+        data, noise=noise, freqs=freqs, filter_centers=[0], filter_half_widths=[50e-9], wgts=(~mask).astype(float)
     )
     assert np.allclose(~wgts.astype(bool), mask)
 
     # Identify RFI with multiple filter centers/half-widths
-    wgts = xrfi.dpss_flagger(
-        data, freqs=freqs, filter_centers=[0, -2700e-9, 2700e-9], filter_half_widths=[50e-9, 10e-9, 10e-9],
+    wgts = xrfi.detrend_dpss_filt(
+        data, noise=noise, freqs=freqs, filter_centers=[0, -2700e-9, 2700e-9], filter_half_widths=[50e-9, 10e-9, 10e-9],
     )
     assert np.allclose(~wgts.astype(bool), mask)
     
-def test_channel_diff_flagger():
+def test_detrend_channel_diff_filt():
     freqs = np.linspace(50e6, 250e6, 500)
     df = np.diff(freqs)[0]
     dt = 10
@@ -258,11 +252,11 @@ def test_channel_diff_flagger():
     noise = np.abs(data) / np.sqrt(intcnt / 2)
     
     # Identify RFI
-    wgts = xrfi.channel_diff_flagger(data, noise=noise,)
+    wgts = xrfi.detrend_channel_diff_filt(data, noise=noise)
     assert np.allclose(~wgts.astype(bool), mask)
     
     # Identify RFI w/ weights grid provided
-    wgts = xrfi.channel_diff_flagger(
+    wgts = xrfi.detrend_channel_diff_filt(
         data, noise=noise, wgts=(~mask).astype(float)
     )
     assert np.allclose(~wgts.astype(bool), mask)
@@ -278,14 +272,14 @@ def test_flag_autos():
     int_count = int(inttime * chan_res)
     
      # Check weights array and array_wgts are the correct size
-    wgts, array_wgts = xrfi.flag_autos(autos, flag_method='channel_diff_flagger')
+    wgts, array_wgts = xrfi.flag_autos(autos, flag_method='detrend_channel_diff_filt')
     assert len(wgts) == len(autos)
     assert array_wgts.shape == autos[(36, 36, 'ee')].shape
     
     # Run with AntennaClassification object
     auto_power_class = ant_class.auto_power_checker(data, good=(2, 30), suspect=(1, 80))
     wgts, array_wgts = xrfi.flag_autos(
-        autos, flag_method='channel_diff_flagger', int_count=int_count, antenna_class=auto_power_class
+        autos, flag_method='detrend_channel_diff_filt', int_count=int_count, antenna_class=auto_power_class
     )
     # Check correct weight dictionary is the correct size
     assert len(wgts) == len(autos)
@@ -300,6 +294,28 @@ def test_flag_autos():
     
     # Confirm function raises ValueError when undefined flagger requested
     pytest.raises(ValueError, xrfi.flag_autos, autos, 'undefined_function')
+
+def test_auto_rfi_checker():
+    """
+    """
+    # Create mock flag weights
+    ants = [(i, 'Jee') for i in range(10)]
+    array_wgts = np.ones(1000)
+    array_wgts[np.random.choice(array_wgts.shape[0], size=5, replace=False)] = 0
+    auto_wgts = {k: np.copy(array_wgts) for k in ants}
+
+    # Add additional flagged channels to antenna (2, 'Jee')
+    idx = np.random.choice(np.where(array_wgts)[0], replace=False, size=100)
+    auto_wgts[(2, 'Jee')][idx] = 0
+
+    # Check to see if (2, 'Jee') is bad
+    rfi_class = xrfi.auto_rfi_checker(auto_wgts, array_wgts, good=(0, 1), suspect=(1, 3))
+    assert rfi_class.is_bad((2, 'Jee'))
+    
+    # Make sure other antennas are listed as good
+    for ant in ants:
+        if ant != (2, 'Jee'):
+            assert rfi_class.is_good(ant)
 
 
 @pytest.fixture(scope='function')

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup_args = {
         'pyyaml',
         'numpy>=1.10',
         'pyuvdata',
+        'hera_filters',
     ],
     'tests_require': ['pytest'],
     'zip_safe': False,


### PR DESCRIPTION
This PR implements new RFI flagging functions for auto-correlation using channel differencing and DPSS filtering from @AaronParsons [fastcal notebook](https://github.com/HERA-Team/hera_notebook_templates/blob/ef53071cfac322a6fe9d629d0ed508028bd1fe3c/notebooks/fastcal_inspect.ipynb).

