### PR TITLE
Antenna Classification Tweaks

### DIFF
--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -314,14 +314,15 @@ def auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=100, fi
     auto_bls = [bl for bl in data if (bl[0] == bl[1]) and (split_pol(bl[2])[0] == split_pol(bl[2])[1])]
 
     # compute relative slope over the band
-    relative_slopes = {}
+    relative_slopes = {bl: 0 for bl in auto_bls}
     for bl in auto_bls:
         mean_data = np.mean(data[bl], axis=0)
         med_filt = median_filter(mean_data, size=filt_size)[edge_cut:-edge_cut]
         fit = np.polyfit(np.linspace(-.5, .5, len(mean_data))[edge_cut:-edge_cut], med_filt, 1)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="invalid value encountered")
-            relative_slopes[bl] = (fit[0] / fit[1] if np.isfinite(fit[1]) else np.sign(fit[0]) * np.inf)
+            if not np.all(med_filt == 0):
+                relative_slopes[bl] = (fit[0] / fit[1] if np.isfinite(fit[1]) else np.sign(fit[0]) * np.inf)
 
     return antenna_bounds_checker(relative_slopes, good=good, suspect=suspect, bad=(-np.inf, np.inf))
 

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -216,7 +216,8 @@ def test_auto_rfi_checker():
     data[(83, 83, 'ee')][:, idx] *= 1.2 # Suspect auto
 
     # Run RFI checker
-    auto_rfi_class = ant_class.auto_rfi_checker(data, antenna_class=auto_class, kernel_widths=[1, 2], filter_centers=[0, 2700e-9, -2700e-9],
+    auto_rfi_class = ant_class.auto_rfi_checker(data, antenna_class=auto_class, good=(0, 0.1), suspect=(0.1, 0.2),
+                                                kernel_widths=[1, 2], filter_centers=[0, 2700e-9, -2700e-9],
                                                 filter_half_widths=[200e-9, 200e-9, 200e-9])
     assert (36, 'Jee') in auto_rfi_class.bad_ants
     assert (83, 'Jee') in auto_rfi_class.suspect_ants


### PR DESCRIPTION
This PR does two things.

First, it fixes a bug where auto_slope_checker fails to classify antennas with all 0s in the data because they yield nans. This classifies them as having slope zero.

Second, and more importantly, this changes the behavior of auto_rfi_checker to look for excess RFI not seen across the whole array, rather than the fraction of the band. In my experiments, I found that the previous method was having a hard time with antennas like the red one near the top here, but looking for an absolute bound on excess RFI does the trick nicely.

![image](https://user-images.githubusercontent.com/5281139/193330845-29b4f88f-5d40-4500-bede-aa15544a1c64.png)
