### PR TITLE
Slight speedup of `even_odd_zeros_checker()`

### DIFF
--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -415,7 +415,7 @@ def even_odd_zeros_checker(sum_data, diff_data, good=(0, 2), suspect=(2, 8)):
         odd_zeros = np.sum((sum_data[bl] - diff_data[bl]) == 0, axis=1)
         max_zeros_per_spectrum[bl] = np.max([even_zeros, odd_zeros])
         for ant in split_bl(bl):
-            zero_count_by_ant[ant] += np.sum([even_zeros, odd_zeros])
+            zero_count_by_ant[ant] += max_zeros_per_spectrum[bl]
     
     # sort dictionary of antennas by number of even/odd visibility zeros it participates in
     zero_count_by_ant = {k: v for k, v in sorted(zero_count_by_ant.items(), key=lambda item: item[1], reverse=True)}


### PR DESCRIPTION
This PR speeds up even_odd_zeros_checker by about 25% by not doing a separate sum calculation for `zero_count_by_ant` which is only used to order antennas.

FYI, just tested the speedup of even_odd_zeros_checker that @tyler-a-cox and @AaronParsons  discussed today.  Unfortunately, it makes it less reliable, because there are many more instances where the data and diff_data have the same real component than cases where both the real and imaginary components match. I’m finding baselines with ~20 matches, which is getting uncomfortably close to the size of an X-engine (making absolute bounds trickier). It may be that those antennas are also broken in some other way, but I’d rather eat the extra second and make this a clean test that clearly reports out which antennas are dropping packets or have broken X-engines.