### PR TITLE
Minor calc_corr_stats() speedup in ant_metrics

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -107,7 +107,7 @@ def calc_corr_stats(data_sum, data_diff=None, flags=None, time_alg=np.nanmean, f
         data_sum_here = np.where(flags_here, data_sum[bl], np.nan)
 
         # check to see if the sum file is mostly zeros, in which case the antenna is totally dead
-        if np.all(flags_here) | np.mean(data_sum_here[~flags_here]) > 0.5:
+        if np.all(flags_here) or np.mean(data_sum_here[~flags_here]) > 0.5:
             corr_stats[bl] = 0
             continue
 

--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -104,10 +104,10 @@ def calc_corr_stats(data_sum, data_diff=None, flags=None, time_alg=np.nanmean, f
         flags_here = ~np.isfinite(data_sum[bl])
         if flags is not None:
             flags_here |= flags[bl]
-        data_sum_here = np.where(flags_here, data_sum[bl], np.nan)
+        data_sum_here = np.where(flags_here, np.nan, data_sum[bl])
 
         # check to see if the sum file is mostly zeros, in which case the antenna is totally dead
-        if np.all(flags_here) or np.mean(data_sum_here[~flags_here]) > 0.5:
+        if np.all(flags_here) or np.mean(data_sum_here[~flags_here] == 0) > 0.5:
             corr_stats[bl] = 0
             continue
 

--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -101,13 +101,13 @@ def calc_corr_stats(data_sum, data_diff=None, flags=None, time_alg=np.nanmean, f
     corr_stats = {}
     for bl in data_sum:
         # turn flags and other non-finite data into nans
-        data_sum_here = np.where(np.isfinite(data_sum[bl]), data_sum[bl], np.nan)
+        flags_here = ~np.isfinite(data_sum[bl])
         if flags is not None:
-            data_sum_here[flags[bl]] = np.nan
+            flags_here |= flags[bl]
+        data_sum_here = np.where(flags_here, data_sum[bl], np.nan)
 
         # check to see if the sum file is mostly zeros, in which case the antenna is totally dead
-        med_abs_sum = np.nanmedian(np.abs(data_sum_here))
-        if med_abs_sum == 0:
+        if np.all(flags_here) | np.mean(data_sum_here[~flags_here]) > 0.5:
             corr_stats[bl] = 0
             continue
 


### PR DESCRIPTION
This PR avoids an unnecessary nanmedian speeding up calc_corr_stats() from 11.3s to 9.16s on a pre-loaded file from last night (which is the dominant component of ant_metrics, which takes 13.2 s).

I can't see a way of making calc_corr_stats much faster without vastly increasing the memory footprint by building a giant array of visibilities from many baselines and then doing some clever vectorization of the code. @tyler-a-cox if you have any ideas, I'm all ears.