### PR TITLE
Add option to not use cache xrfi.dpss_flagger

### DIFF
--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -328,8 +328,8 @@ def auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=100, fi
 
 from hera_qm.ant_class import antenna_bounds_checker
 def auto_rfi_checker(data, good=(0, 0.01), suspect=(0.01, 0.02), nsig=6, antenna_class=None, flag_broadcast_thresh=0.5, 
-                     kernel_widths=[3, 4, 5], mode='dpss_matrix', filter_centers=[0],
-                     filter_half_widths=[200e-9], eigenval_cutoff=[1e-9]):
+                     kernel_widths=[3, 4, 5], mode='dpss_matrix', filter_centers=[0], filter_half_widths=[200e-9], 
+                     eigenval_cutoff=[1e-9], cache=None):
     """
     Classifies ant-pols as good, suspect, or bad based on the fraction of channels flagged in that are not among the 
     array-broadcast flags (i.e. channels flagged for >50% of antennas). Flagging takes place in two steps: 
@@ -376,7 +376,7 @@ def auto_rfi_checker(data, good=(0, 0.01), suspect=(0.01, 0.02), nsig=6, antenna
     # Flag using DPSS filters
     antenna_flags, array_flags = xrfi.flag_autos(data, freqs=data.freqs, flag_method="dpss_flagger", nsig=nsig, antenna_class=antenna_class,
                                                  filter_centers=filter_centers, filter_half_widths=filter_half_widths,
-                                                 eigenval_cutoff=eigenval_cutoff, flags=antenna_flags, mode=mode)
+                                                 eigenval_cutoff=eigenval_cutoff, flags=antenna_flags, mode=mode, cache=cache)
     
     
     # Calculate the excess fraction of the band that is flagged

--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -360,6 +360,10 @@ def auto_rfi_checker(data, good=(0, 0.01), suspect=(0.01, 0.02), nsig=6, antenna
             list of floats of centers of delay filter windows in nanosec. Only used in "dpss_flagger"
         filter_half_widths: array-like, default=[200e-9]
             list of floats of half-widths of delay filter windows in nanosec. Only used in "dpss_flagger"
+        cache: dictionary, default=None
+            Dictionary for caching fitting matrices. By default this value is None to prevent the size of the cached
+            matrices from getting too large. By passing in a cache dictionary, this function could be much faster, but
+            the memory requirement will also increase.
         
     Returns:
         AntennaClassification with "good", "suspect", and "bad" ant-pols based on the absolute fraction of 

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -231,7 +231,7 @@ def robust_divide(num, den):
 
 def dpss_flagger(data, noise, freqs, filter_centers, filter_half_widths, flags=None,
                  nsig=6, mode="dpss_solve", eigenval_cutoff=[1e-9],
-                 suppression_factors=[1e-9], cache={}):
+                 suppression_factors=[1e-9], cache=None):
     """
     Identify RFI in visibilities by filtering data with discrete prolate spheroidal sequences. Returns a boolean array of flags
     with values of True indicating channels flagged for RFI

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -261,8 +261,10 @@ def dpss_flagger(data, noise, freqs, filter_centers, filter_half_widths, flags=N
     suppression_factors: array-like, default=[1e-9]
         Specifies the fractional residuals of model to leave in the data. For example, 1e-6 means that the filter
         will leave in 1e-6 of data fitted by the model.
-    cache: dictionary, default={}
-        dictionary for caching fitting matrices.
+    cache: dictionary, default=None
+        Dictionary for caching fitting matrices. By default this value is None to prevent the size of the cached
+        matrices from getting too large. By passing in a cache dictionary, this function could be much faster, but
+        the memory requirement will also increase.
 
     Returns:
     -------


### PR DESCRIPTION
By default, `xrfi.dpss_flagger` currently uses a cache to store intermediate filtering matrices, which speed up flagging. These matrices can get quite large, and if flagging patterns are different from antenna to antenna, the memory requirement of these functions could be high. By default, I've set the cache matrix to `None` in `ant_class.auto_rfi_flagger` and `xrfi.dpss_flagger` to decrease the memory requirement of those functions. Adding a cache does improve the performance of `ant_class.auto_rfi_flagger` though.

<img width="679" alt="Screen Shot 2022-10-10 at 10 43 22 AM" src="https://user-images.githubusercontent.com/17678594/194924716-74ca00e4-e234-4fb0-87b5-00f047ce0d82.png">
