### PR TITLE
Change default of auto_rfi_flagger to use cache

### DIFF
--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -329,7 +329,7 @@ def auto_slope_checker(data, good=(-.2, .2), suspect=(-.4, .4), edge_cut=100, fi
 from hera_qm.ant_class import antenna_bounds_checker
 def auto_rfi_checker(data, good=(0, 0.01), suspect=(0.01, 0.02), nsig=6, antenna_class=None, flag_broadcast_thresh=0.5, 
                      kernel_widths=[3, 4, 5], mode='dpss_matrix', filter_centers=[0], filter_half_widths=[200e-9], 
-                     eigenval_cutoff=[1e-9], cache=None):
+                     eigenval_cutoff=[1e-9], cache={}):
     """
     Classifies ant-pols as good, suspect, or bad based on the fraction of channels flagged in that are not among the 
     array-broadcast flags (i.e. channels flagged for >50% of antennas). Flagging takes place in two steps: 


### PR DESCRIPTION
This PR changes the default of `ant_class.auto_rfi_flagger` to use a cache by default. User can still choose to not use a cache though.

<img width="665" alt="Screen Shot 2022-10-11 at 10 06 52 AM" src="https://user-images.githubusercontent.com/17678594/195156178-71e4c9dd-3be8-46f1-8ec5-d8623ddbb372.png">
