### PR TITLE
Enable flagging autos for missing RFI

### DIFF
--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -368,20 +368,20 @@ def auto_shape_checker(data, good=(0, 0.0625), suspect=(0.0625, 0.125), flag_spe
     return antenna_bounds_checker(distance_metrics, good=good, suspect=suspect, bad=(-np.inf, np.inf))
 
 
-def auto_rfi_checker(data, good=(0, 0.01), suspect=(0.01, 0.02), nsig=6, antenna_class=None, flag_broadcast_thresh=0.5, 
+def auto_rfi_checker(data, good=(-0.02, 0.01), suspect=(-0.04, 0.02), nsig=6, antenna_class=None, flag_broadcast_thresh=0.5, 
                      kernel_widths=[3, 4, 5], mode='dpss_matrix', filter_centers=[0], filter_half_widths=[200e-9], 
                      eigenval_cutoff=[1e-9], cache={}):
     """
-    Classifies ant-pols as good, suspect, or bad based on the fraction of channels flagged in that are not among the 
-    array-broadcast flags (i.e. channels flagged for >50% of antennas). Flagging takes place in two steps: 
+    Classifies ant-pols as good, suspect, or bad based on the excess (or deficit) of fraction of channels flagged on that auto
+    that are not among the array-broadcast flags (i.e. channels flagged for >50% of antennas). Flagging takes place in two steps: 
     (1) "channel_diff_flagger" is used to get an initial set of flags and
     (2) "dpss_flagger" is used with the array averaged flags to refine initial per-antenna flags
  
     Arguments:
         data: DataContainer containing antenna autocorrelations (other baselines ignored)
-        good: 2-tuple or list of 2-tuple, default=(0, 0.01)
+        good: 2-tuple or list of 2-tuple, default=(-0.02, 0.01)
             2-tuple or list of 2-tuple bounds for ranges considered good.
-        suspect: 2-tuple or list of 2-tuple, default=(0.01, 0.02)
+        suspect: 2-tuple or list of 2-tuple, default=(-0.04, 0.02)
             Bounds for ranges considered suspect.
         nsig: float, default=6
             The number of sigma in the metric above which to flag pixels. Used in both steps.
@@ -424,8 +424,8 @@ def auto_rfi_checker(data, good=(0, 0.01), suspect=(0.01, 0.02), nsig=6, antenna
                                                  eigenval_cutoff=eigenval_cutoff, flags=antenna_flags, mode=mode, cache=cache)
     
     
-    # Calculate the excess fraction of the band that is flagged
-    flagged_fraction = {bls: np.mean(flags | array_flags) - np.mean(array_flags) for bls, flags in antenna_flags.items()}
+    # Calculate the excess (or deficit) fraction of the band that is flagged
+    flagged_fraction = {bls: np.mean(flags) - np.mean(array_flags) for bls, flags in antenna_flags.items()}
 
     return antenna_bounds_checker(flagged_fraction, good=good, suspect=suspect, bad=(-np.inf, np.inf))
 

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -237,11 +237,12 @@ def test_auto_rfi_checker():
     data[(83, 83, 'ee')][:, idx] *= 1.2 # Suspect auto
 
     # Run RFI checker
-    auto_rfi_class = ant_class.auto_rfi_checker(data, antenna_class=auto_class, good=(0, 0.1), suspect=(0.1, 0.2),
+    auto_rfi_class = ant_class.auto_rfi_checker(data, antenna_class=auto_class, good=(-.2, 0.1), suspect=(-.4, 0.2),
                                                 kernel_widths=[1, 2], filter_centers=[0, 2700e-9, -2700e-9],
                                                 filter_half_widths=[200e-9, 200e-9, 200e-9])
-    assert (36, 'Jee') in auto_rfi_class.bad_ants
-    assert (83, 'Jee') in auto_rfi_class.suspect_ants
+    assert auto_rfi_class.bad_ants == set([(68, 'Jnn'), (116, 'Jee'), (68, 'Jee'), (36, 'Jee'), (65, 'Jnn'),
+                                           (135, 'Jee'), (93, 'Jnn'), (65, 'Jee'), (93, 'Jee'), (116, 'Jnn')])
+    assert auto_rfi_class.suspect_ants == set([(83, 'Jee')])
 
     # Make sure antennas that were previously marked bad are still marked bad
     for ant in auto_class.bad_ants:
@@ -249,7 +250,7 @@ def test_auto_rfi_checker():
     
     # Show that all other antennas are marked "good"
     for ant in auto_class.ants:
-        if ant not in [(36, 'Jee'), (83, 'Jee')] and ant not in auto_class.bad_ants:
+        if ant not in auto_rfi_class.suspect_ants and ant not in auto_rfi_class.bad_ants:
             assert ant in auto_rfi_class.good_ants
 
 def test_even_odd_zeros_checker():


### PR DESCRIPTION
This PR enables the flagging of autocorrelations that don't have enough RFI. In practice, this doesn't flag any more antennas (missing RFI usually means other problems) but I think it'll help distinguish FEM off antennas from other issues.