### PR TITLE
Improve ant_metrics handling of zeros

### DIFF
--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -67,7 +67,10 @@ def get_ant_metrics_dict():
 
 
 def calc_corr_stats(data_sum, data_diff=None):
-    """For all baselines, calculate average cross-correlation between even and odd in order to identify dead, cross-polarized, and non-time-locked antennas.
+    """For all baselines, calculate average cross-correlation between even and odd in order 
+    to identify dead, cross-polarized, and non-time-locked antennas. Time and channels where
+    either the even or odd data (or both) are zero are ignored, but if either even or odd 
+    is entirely zero, the corr_stat will be np.nan.
 
     Parameters
     ----------
@@ -102,12 +105,9 @@ def calc_corr_stats(data_sum, data_diff=None):
             even = data_sum_here[0:last_int:2, :]
             odd = data_sum_here[1:last_int:2, :]
 
-        # normalize (reduces the impact of RFI by making every channel equally weighted)
-        np.divide(even, np.abs(even), out=even)
-        np.divide(odd, np.abs(odd), out=odd)
-
-        # reduce to a scalar statistic
-        corr_stats[bl] = np.abs(np.sum(even * np.conj(odd))) / even.size
+        # reduce to a scalar statistic, normalized to reduce the impact of RFI by equally weighting channels
+        product = even * np.conj(odd)
+        corr_stats[bl] = np.abs(np.nanmean(np.where(product == 0, np.nan, product / np.abs(product))))
 
     return corr_stats
 

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -22,8 +22,6 @@ def test_calc_corr_stats():
                 (0, 1, 'nn'): np.array([[10.0j, 10.0], [20.0 + 100j, 10.0]])}
     data_diff = {(0, 1, 'ee'): np.array([[0.0, 1.0 + 1.0j], [1.0, 3.0]]),
                 (0, 1, 'nn'): np.array([[3.0, 1.0j], [0.0, 2.0]])}
-    flags = {(0, 1, 'ee'): np.array([[False, False], [False, False]]),
-                (0, 1, 'nn'): np.array([[False, False], [False, False]])}
 
     # test normal operation
     corr_stats = ant_metrics.calc_corr_stats(data_sum,data_diff)
@@ -42,6 +40,14 @@ def test_calc_corr_stats():
     assert corr_stats[(0,1,'nn')] == pytest.approx(1,abs=1e-2)
     assert corr_stats[(0,1,'ee')] == pytest.approx(0.9238,abs=1e-2)
 
+    # test zero/nan handling
+    data_sum = {(0, 1, 'ee'): np.array([[20, 10.0 + 10.0j], [10.0, 30.0]]),
+                (0, 1, 'nn'): np.array([[10.0j, 10.0], [20.0 + 100j, 10.0]])}
+    data_diff = {(0, 1, 'ee'): np.array([[20, 10.0 + 10.0j], [10.0, 29.0]]),
+                (0, 1, 'nn'): np.array([[10.0j, 10.0], [20.0 + 100j, 10.0]])}
+    corr_stats = ant_metrics.calc_corr_stats(data_sum, data_diff)
+    assert np.isfinite(corr_stats[(0, 1, 'ee')])
+    assert not np.isfinite(corr_stats[(0, 1, 'nn')])
 
 # def test_corr_metrics():
 #     corr_stats = {(0, 1, 'ee'): 1.0,


### PR DESCRIPTION
A recent PR #434 simplified `ant_metrics. calc_corr_stats` but made it less tolerant of zeros appearing in either the odd or even spectrum (or both). As it stands, a single zero in either the even or odd spectrum makes the whole statistic NaN.

If a single X-engine is down, for example, it should still be possible to calculate a corr metric for a given baselines, even if there are some zeros. And in general, we want to do this to help identify white rabbit failures and cross-polarized antennas, which is the purpose of ant_metrics.  This PR robustifies the calculation using a using a nanmean.

If there are zeros in the spectrum, `ant_class. even_odd_zeros_checker` is the right tool to diagnose that. If an antenna is totally dead, we already have a way to handle that in ant_metrics.

This PR adds a test to expose this issue. It also speeds up calc_corr_stats by ~15% by avoiding repeating the multiplication and normalization.