### PR TITLE
Minor speed-up to x-engine checker

### DIFF
--- a/hera_qm/ant_class.py
+++ b/hera_qm/ant_class.py
@@ -483,7 +483,7 @@ def even_odd_zeros_checker(sum_data, diff_data, good=(0, 2), suspect=(2, 8)):
 
 
 def non_noiselike_diff_by_xengine_checker(sum_data, diff_data, flag_waterfall=None, antenna_class=None,
-                                          xengine_chans=96, bad_xengine_zcut=10):
+                                          xengine_chans=96, bad_xengine_zcut=10, assume_same_dt=False):
     '''Classifies ant-pols as good or bad based on whether an an x-engine shows excess power
     in the diffs beyond what is expected from thermal noise. This is useful for detecting
     anomolous data in either the evens or the odds, like stale packets. The failure is attributed
@@ -499,7 +499,9 @@ def non_noiselike_diff_by_xengine_checker(sum_data, diff_data, flag_waterfall=No
         xengine_chans: Number of channels in a given x-engine. Must evenly divide the second dimension
             of the data waterfalls. 
         bad_xengine_zcut: Cut in number of sigmas beyond which a given x-engine is considered "bad".
-                
+        assume_same_dt: Boolean parameter that, if True, assumes that all baselines within sum_data
+            have the same integration time. Can provide a moderate speed-up of this function if True. 
+            Default is False.
      Returns:
          AntennaClassification with "good" and "bad" ant-pols, where "bad" has at least one bad x-engine
      '''

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -304,6 +304,13 @@ def test_non_noiselike_diff_by_xengine_checker():
         assert ac[(ant, 'Jee')] == 'good'
     for ant in [3, 7, 8]:
         assert ac[(ant, 'Jee')] == 'bad'
+
+    # Check that using assume_same_dt yields the same result
+    ac = ant_class.non_noiselike_diff_by_xengine_checker(sums, diffs, assume_same_dt=True)
+    for ant in [0, 1, 2, 4, 5, 6, 9]:
+        assert ac[(ant, 'Jee')] == 'good'
+    for ant in [3, 7, 8]:
+        assert ac[(ant, 'Jee')] == 'bad'
         
     ac = ant_class.non_noiselike_diff_by_xengine_checker(sums, diffs, antenna_class=ant_class.AntennaClassification(bad=[(3, 'Jee')]))
     for ant in [0, 1, 2, 4, 5, 6, 9]:


### PR DESCRIPTION
This PR makes a couple minor changes to `ant_class.non_noiselike_xengine_checker` to improve its computational performance. Function now pre-computes the channel width and gives the user the option to pre-compute the integration time. Prior to this change, `predict_noise_variance_from_autos` would recompute these values for each baseline.