### PR TITLE
ci: add warnings tests and fix some warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10', "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/warnings-tests.yml
+++ b/.github/workflows/warnings-tests.yml
@@ -1,0 +1,49 @@
+name: Run Warnings Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  warnings:
+    name: Warnings Tests
+    env:
+      ENV_NAME: hera_qm_tests
+      PYTHON: ${{ matrix.python-version }}
+      OS: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.11"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: 1
+
+    - name: Get Miniconda (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh;
+        bash $HOME/miniconda.sh -b -p $HOME/miniconda
+
+    - name: Setup Environment
+      run: |
+        export PATH="$HOME/miniconda/bin:$PATH"
+        ./ci/install_conda.sh
+
+    - name: Install
+      run: |
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate ${ENV_NAME}
+        pip install .
+
+    - name: Run Tests
+      run: |
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate $ENV_NAME
+        pytest -W error

--- a/.github/workflows/warnings-tests.yml
+++ b/.github/workflows/warnings-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
       fail-fast: false
 
     steps:

--- a/hera_qm/ant_metrics.py
+++ b/hera_qm/ant_metrics.py
@@ -109,7 +109,8 @@ def calc_corr_stats(data_sum, data_diff=None):
         product = even * np.conj(odd)
         where_nonzero = (product != 0)
         if np.any(where_nonzero):
-            ratio = product / np.abs(product)
+            with np.errstate(divide='ignore', invalid='ignore'):
+                ratio = product / np.abs(product)
             corr_stats[bl] = np.abs(np.mean(ratio[where_nonzero]))
         else:
             corr_stats[bl] = np.nan

--- a/hera_qm/tests/conftest.py
+++ b/hera_qm/tests/conftest.py
@@ -6,7 +6,8 @@
 import pytest
 from astropy.utils import iers
 from astropy.time import Time
-
+import warnings
+import numpy as np
 
 @pytest.fixture(autouse=True, scope="session")
 def setup_and_teardown_package():
@@ -23,6 +24,9 @@ def setup_and_teardown_package():
     except (Exception):
         iers.conf.auto_max_age = None
 
-    yield
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=np.exceptions.ComplexWarning)
+
+        yield
 
     iers.conf.auto_max_age = 30

--- a/hera_qm/tests/conftest.py
+++ b/hera_qm/tests/conftest.py
@@ -24,9 +24,6 @@ def setup_and_teardown_package():
     except (Exception):
         iers.conf.auto_max_age = None
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=np.exceptions.ComplexWarning)
-
-        yield
+    yield
 
     iers.conf.auto_max_age = 30

--- a/hera_qm/tests/test_ant_class.py
+++ b/hera_qm/tests/test_ant_class.py
@@ -220,6 +220,7 @@ def test_auto_shape_checker():
         assert ant in auto_shape_class.bad_ants
 
 
+@pytest.mark.filterwarnings("ignore::numpy.exceptions.ComplexWarning")
 def test_auto_rfi_checker():
     hd = io.HERADataFastReader(DATA_PATH + '/zen.2459122.49827.sum.downselected.uvh5')
     data, _, _ = hd.read(read_flags=False, read_nsamples=False)

--- a/hera_qm/tests/test_ant_metrics.py
+++ b/hera_qm/tests/test_ant_metrics.py
@@ -282,6 +282,7 @@ def test_iterative_antenna_metrics_and_flagging():
     assert am.final_metrics['corrXPol'][(87, 'Jnn')] == am.all_metrics[3]['corrXPol'][(87, 'Jnn')]
     assert am.final_metrics['corrXPol'][(87, 'Jee')] == am.all_metrics[3]['corrXPol'][(87, 'Jee')]
 
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered")
 def test_find_totally_dead_ants():
     files = {'sum_files': DATA_PATH + '/zen.2459122.49827.sum.downselected.uvh5',
              'diff_files': DATA_PATH + '/zen.2459122.49827.diff.downselected.uvh5'}

--- a/hera_qm/tests/test_auto_metrics.py
+++ b/hera_qm/tests/test_auto_metrics.py
@@ -11,6 +11,7 @@ from hera_qm import auto_metrics
 from hera_qm import metrics_io
 from hera_qm.data import DATA_PATH
 import hera_qm.tests as qmtest
+import warnings
 
 
 def test_nanmad():
@@ -101,7 +102,10 @@ def test_get_auto_spectra():
 
     # test with totally flagged channel
     flags[:, 1] = True
-    spectra = auto_metrics.get_auto_spectra(autos, flag_wf=flags, time_avg_func=np.nanmean, scalar_norm=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Mean of empty slice")
+        spectra = auto_metrics.get_auto_spectra(autos, flag_wf=flags, time_avg_func=np.nanmean, scalar_norm=False)
+    
     np.testing.assert_array_equal(spectra[0, 0, 'ee'], 10 * np.array([1., np.nan, 1., 1., 1.]))
     np.testing.assert_array_equal(spectra[1, 1, 'ee'], 10 * np.array([1., np.nan, 1., 1., 1.]))
 
@@ -215,7 +219,10 @@ def test_auto_metrics_run():
     # run main function on downselected H4C data, then read results
     auto_files = glob.glob(os.path.join(DATA_PATH, 'zen.2459122.*.sum.autos.downselected.uvh5'))
     metrics_outfile = os.path.join(DATA_PATH, 'unittest_auto_metrics.h5')
-    ex_ants, modzs, spectra, flags = auto_metrics.auto_metrics_run(metrics_outfile, auto_files,
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="All-NaN slice encountered")
+        warnings.filterwarnings("ignore", message="K1 value 8 is larger than the data of dimension 4; using the size of the data for the kernel size")
+        ex_ants, modzs, spectra, flags = auto_metrics.auto_metrics_run(metrics_outfile, auto_files,
                                                                    median_round_modz_cut=75., mean_round_modz_cut=5.,
                                                                    edge_cut=100, Kt=8, Kf=8, sig_init=5.0, sig_adj=2.0, 
                                                                    chan_thresh_frac=.05, history='unittest', overwrite=True)

--- a/hera_qm/tests/test_firstcal_metrics.py
+++ b/hera_qm/tests/test_firstcal_metrics.py
@@ -14,16 +14,20 @@ import hera_qm.tests as qmtest
 from hera_qm import metrics_io
 import sys
 import pytest
+import warnings
 
 pytestmark = pytest.mark.filterwarnings(
-    "ignore:telescope_location is not set. Using known values for HERA.",
-    "ignore:antenna_positions is not set. Using known values for HERA."
+    "ignore:.*Using known values for HERA",
+    "ignore:.*Increasing the bound and calling fit again may find a better value",
+    "ignore:.*Decreasing the bound and calling fit again may find a better value",
+    
 )
 
 @pytest.fixture(scope='function')
 def firstcal_setup():
     infile = os.path.join(DATA_PATH, 'zen.2457555.50099.yy.HH.uvcA.first.calfits')
     FC = firstcal_metrics.FirstCalMetrics(infile)
+    
     out_dir = os.path.join(DATA_PATH, 'test_output')
 
     class DataHolder():
@@ -88,22 +92,26 @@ def test_write_load_metrics(firstcal_setup):
     if os.path.isfile(outfile):
         os.remove(outfile)
     # write json
-    firstcal_setup.FC.write_metrics(filename=outfile, filetype='json')
+    with pytest.warns(PendingDeprecationWarning, match="JSON-type files can still be written but are no longer written by default"):
+        firstcal_setup.FC.write_metrics(filename=outfile, filetype='json')
     assert os.path.isfile(outfile)
     # load json
-    firstcal_setup.FC.load_metrics(filename=outfile)
+    with pytest.warns(PendingDeprecationWarning, match="JSON-type files can still be read but are no longer written by default"):
+        firstcal_setup.FC.load_metrics(filename=outfile)
     assert len(firstcal_setup.FC.metrics.keys()) == num_keys
     # erase
     os.remove(outfile)
+
     # write pickle
     outfile = os.path.join(firstcal_setup.out_dir, 'firstcal_metrics.pkl')
     if os.path.isfile(outfile):
         os.remove(outfile)
-
-    firstcal_setup.FC.write_metrics(filename=outfile, filetype='pkl')
+    with pytest.warns(PendingDeprecationWarning, match="Pickle-type files can still be written but are no longer written by default"):
+        firstcal_setup.FC.write_metrics(filename=outfile, filetype='pkl')
     assert os.path.isfile(outfile)
     # load pickle
-    firstcal_setup.FC.load_metrics(filename=outfile)
+    with pytest.warns(PendingDeprecationWarning, match="Pickle-type files can still be read but are no longer written by default"):
+        firstcal_setup.FC.load_metrics(filename=outfile)
     assert len(firstcal_setup.FC.metrics.keys()) == num_keys
     os.remove(outfile)
 
@@ -124,12 +132,14 @@ def test_write_load_metrics(firstcal_setup):
     outfile = os.path.join(firstcal_setup.out_dir, 'firstcal_metrics.txt')
     pytest.raises(IOError, firstcal_setup.FC.load_metrics, filename=outfile)
     outfile = firstcal_setup.FC.fc_filestem + '.first_metrics.json'
-    firstcal_setup.FC.write_metrics(filetype='json')  # No filename
+    with pytest.warns(PendingDeprecationWarning, match="JSON-type files can still be written but are no longer written by default"):
+        firstcal_setup.FC.write_metrics(filetype='json')  # No filename
     assert os.path.isfile(outfile)
     os.remove(outfile)
 
     outfile = firstcal_setup.FC.fc_filestem + '.first_metrics.pkl'
-    firstcal_setup.FC.write_metrics(filetype='pkl')  # No filename
+    with pytest.warns(PendingDeprecationWarning, match="Pickle-type files can still be written but are no longer written by default"):
+        firstcal_setup.FC.write_metrics(filetype='pkl')  # No filename
     assert os.path.isfile(outfile)
     os.remove(outfile)
 
@@ -256,11 +266,17 @@ def firstcal_twopol():
     del(firstcal_twopol)
 
 
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered")
+@pytest.mark.filterwarnings("ignore:Mean of empty slice")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
 def test_init_two_pol(firstcal_twopol):
     assert firstcal_twopol.FC.Nants == 11
     assert len(firstcal_twopol.FC.delays) == 11
 
 
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered")
+@pytest.mark.filterwarnings("ignore:Mean of empty slice")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
 def test_run_metrics_two_pols(firstcal_twopol):
     # These results were run with a seed of 0, the seed shouldn't matter
     # but you never know.

--- a/hera_qm/tests/test_metrics_io.py
+++ b/hera_qm/tests/test_metrics_io.py
@@ -15,7 +15,7 @@ import hera_qm.tests as qmtest
 from hera_qm import __version__
 
 
-class dummy_class(object):
+class dummy_class:
     """A dummy class to break h5py object types."""
 
     def __init__(self):
@@ -464,6 +464,7 @@ def test_process_ex_ants_bad_string():
 
 
 @pytest.mark.parametrize('extension', ['hdf5', 'json'])
+@pytest.mark.filterwarnings("ignore:JSON-type files can still be read but are no longer written by default.")
 def test_process_ex_ants_string_and_file(extension):
     ex_ants = '0,1'
     met_file = os.path.join(DATA_PATH, f'example_ant_metrics.{extension}')

--- a/hera_qm/tests/test_omnical_metrics.py
+++ b/hera_qm/tests/test_omnical_metrics.py
@@ -12,8 +12,7 @@ import pytest
 import numpy as np
 
 pytestmark = pytest.mark.filterwarnings(
-    "ignore:telescope_location is not set. Using known values for HERA.",
-    "ignore:antenna_positions is not set. Using known values for HERA."
+    "ignore:.*Using known values for HERA",
 )
 
 @pytest.fixture(scope='function')

--- a/hera_qm/tests/test_utils.py
+++ b/hera_qm/tests/test_utils.py
@@ -169,6 +169,7 @@ def test_get_metrics_ArgumentParser_xrfi_h3c_idr2_1_run():
     assert len(args.ocalfits_files) == 2
 
 
+@pytest.mark.filterwarnings("ignore:JSON-type files can still be read but are no longer written by default")
 def test_metrics2mc():
     # test ant metrics
     filename = os.path.join(DATA_PATH, 'example_ant_metrics.hdf5')

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -41,8 +41,7 @@ for cnum, cf, uvf in zip(range(3), test_c_files, test_uvh5_files):
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The uvw_array does not match the expected values given the antenna positions.",
-    "ignore:telescope_location is not set. Using known values for HERA.",
-    "ignore:antenna_positions is not set. Using known values for HERA.",
+    "ignore:.*Using known values for HERA",
 )
 
 
@@ -1259,6 +1258,7 @@ def test_xrfi_h1c_idr2_2_pipe(uvcal_calfits):
     assert len(uvf_m.polarization_array) == 1
     assert uvf_m.weights_array.max() == 1.
 
+@pytest.mark.filterwarnings("ignore:K1 value 8 is larger than the data of dimension 3")
 def test_xrfi_run_step(tmpdir):
     # setup files in tmpdir.
     tmp_path = tmpdir.strpath
@@ -2119,6 +2119,7 @@ def test_day_threshold_run(tmpdir):
     uvc = UVCal.from_file(ocal_file, use_future_array_shapes=True)
     dt = (uvc.time_array.max() - uvc.time_array.min()) + uvc.integration_time.mean() / (24. * 3600.)
     uvc.time_array += dt
+    uvc.set_lsts_from_time_array()
     ocal_file = os.path.join(tmp_path, fake_obses[1] + '.omni.calfits')
     uvc.write_calfits(ocal_file)
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
@@ -2197,6 +2198,7 @@ def test_day_threshold_run_yaml(tmpdir):
     uvc = UVCal.from_file(ocal_file, use_future_array_shapes=True)
     dt = (uvc.time_array.max() - uvc.time_array.min()) + uvc.integration_time.mean() / (24. * 3600.)
     uvc.time_array += dt
+    uvc.set_lsts_from_time_array()
     ocal_file = os.path.join(tmp_path, fake_obses[1] + '.omni.calfits')
     uvc.write_calfits(ocal_file)
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
@@ -2224,7 +2226,7 @@ def test_day_threshold_run_yaml(tmpdir):
         calfile = os.path.join(tmp_path, fake_obs + '.flagged_abs.calfits')
         assert os.path.exists(calfile)
 
-
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered")
 def test_day_threshold_run_data_only(tmpdir):
     # The warnings are because we use UVFlag.to_waterfall() on the total chisquareds
     # This doesn't hurt anything, and lets us streamline the pipe
@@ -2258,6 +2260,7 @@ def test_day_threshold_run_data_only(tmpdir):
     uvc = UVCal.from_file(ocal_file, use_future_array_shapes=True)
     dt = (uvc.time_array.max() - uvc.time_array.min()) + uvc.integration_time.mean() / (24. * 3600.)
     uvc.time_array += dt
+    uvc.set_lsts_from_time_array()
     ocal_file = os.path.join(tmp_path, fake_obses[1] + '.omni.calfits')
     uvc.write_calfits(ocal_file)
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
@@ -2320,6 +2323,7 @@ def test_day_threshold_run_cal_only(tmpdir):
     uvc = UVCal.from_file(ocal_file, use_future_array_shapes=True)
     dt = (uvc.time_array.max() - uvc.time_array.min()) + uvc.integration_time.mean() / (24. * 3600.)
     uvc.time_array += dt
+    uvc.set_lsts_from_time_array()
     ocal_file = os.path.join(tmp_path, fake_obses[1] + '.omni.calfits')
     uvc.write_calfits(ocal_file)
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
@@ -2384,6 +2388,7 @@ def test_day_threshold_run_omnivis_only(tmpdir):
     uvc = UVCal.from_file(ocal_file, use_future_array_shapes=True)
     dt = (uvc.time_array.max() - uvc.time_array.min()) + uvc.integration_time.mean() / (24. * 3600.)
     uvc.time_array += dt
+    uvc.set_lsts_from_time_array()
     ocal_file = os.path.join(tmp_path, fake_obses[1] + '.omni.calfits')
     uvc.write_calfits(ocal_file)
     acal_file = os.path.join(tmp_path, fake_obses[1] + '.abs.calfits')
@@ -2441,7 +2446,7 @@ def test_xrfi_h1c_run_filename_not_string(uvdata_miriad):
     with pytest.raises(ValueError, match="filename must be string path to file."):
         xrfi.xrfi_h1c_run(uvd, history='Just a test.', filename=5)
 
-
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 def test_xrfi_h1c_run_uvfits_no_xrfi_path():
     # test uvfits file and no xrfi path
     basename = utils.strip_extension(test_uvfits_file)
@@ -2465,7 +2470,7 @@ def test_xrfi_h1c_run_uvfits_no_xrfi_path():
     os.remove(g_temp)
     os.remove(x_temp)
 
-
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 def test_xrfi_h1c_run_uvfits_xrfi_path():
     # test uvfits file with xrfi path
     basename = utils.strip_extension(os.path.basename(test_uvfits_file))
@@ -2491,7 +2496,7 @@ def test_xrfi_h1c_run_miriad_model(uvdata_miriad):
                       model_file_format='miriad', xrfi_path=xrfi_path, kt_size=3)
     assert os.path.exists(outtest)
 
-
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 def test_xrfi_h1c_run_uvfits_model(uvdata_miriad):
     # uvfits model file test
     uvd = uvdata_miriad
@@ -2506,6 +2511,7 @@ def test_xrfi_h1c_run_uvfits_model(uvdata_miriad):
     assert os.path.exists(outtest)
 
 
+@pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 def test_xrfi_h1c_run_incorrect_model(uvdata_miriad):
     # incorrect model
     uvd = uvdata_miriad
@@ -2739,6 +2745,7 @@ def test_xrfi_h3c_idr2_1_run(tmp_path, uvcal_calfits):
         uvc = uvcal_calfits
         dt = (uvc.time_array.max() - uvc.time_array.min()) + uvc.integration_time.mean() / (24. * 3600.)
         uvc.time_array += obsi * dt
+        uvc.set_lsts_from_time_array()
         uvc.write_calfits(ocalfits_files[obsi])
         uvc.write_calfits(acalfits_files[obsi])
 

--- a/hera_qm/tests/test_xrfi.py
+++ b/hera_qm/tests/test_xrfi.py
@@ -2771,3 +2771,14 @@ def test_xrfi_h3c_idr2_1_run(tmp_path, uvcal_calfits):
                 uvf = UVFlag(str(out), use_future_array_shapes=True)
                 assert uvf.label == label
             shutil.rmtree(outdir)  # cleanup
+
+@pytest.mark.parametrize("detrend", [False, True])
+def test_modzscore_complex(detrend):
+    rng = np.random.default_rng(12)
+    data = rng.standard_normal(100) + 1j * rng.standard_normal(100)
+
+    zscore = xrfi.modzscore_1d(data, detrend = detrend)
+    assert np.iscomplexobj(zscore)
+    assert np.isclose(np.mean(zscore.real), 0, atol=1e-1)
+    assert np.isclose(np.mean(zscore.imag), 0, atol=1e-1)
+        

--- a/hera_qm/xrfi.py
+++ b/hera_qm/xrfi.py
@@ -764,16 +764,21 @@ def modzscore_1d(data, flags=None, kern=8, detrend=True):
         footprint[kern] = 0
         data = np.concatenate([data[kern - 1::-1], data, data[:-kern - 1:-1]])
         # detrend in 1D. Do real/imag regardless of whether data are complex because it's cheap.
-        d_sm_r = median_filter(data.real, footprint=footprint)
-        d_sm_i = median_filter(data.imag, footprint=footprint)
-        d_sm = d_sm_r + 1j * d_sm_i
+        d_sm = median_filter(data.real, footprint=footprint)
+
+        if np.iscomplexobj(data):
+            d_sm_i = median_filter(data.imag, footprint=footprint)
+            d_sm = d_sm + 1j * d_sm_i
         d_rs = data - d_sm
         d_sq = np.abs(d_rs)**2
         # Factor of .456 is to put mod-z scores on same scale as standard deviation.
         sig = np.sqrt(median_filter(d_sq, footprint=footprint) / .456)
         zscore = robust_divide(d_rs, sig)[kern:-kern]
     else:
-        d_rs = data - np.nanmedian(data.real) - 1j * np.nanmedian(data.imag)
+        if np.iscomplexobj(data):
+            d_rs = data - np.nanmedian(data.real) - 1j * np.nanmedian(data.imag)
+        else:
+            d_rs = data - np.nanmedian(data)
         d_sq = np.abs(d_rs)**2
         # Factor of .456 is to put mod-z scores on same scale as standard deviation.
         sig = np.sqrt(np.nanmedian(d_sq) / .456)


### PR DESCRIPTION
This adds a pytest run with warnings that error, so we can catch them sooner rather than later.

I went through and fixed some of the errors that popped up. Some other warnings are fixed in #453, so they will disappear once that is merged. Other warnings I have silenced if they seem reasonable to let go, but I would advise quickly looking over all the "filterwarnings" that I added to make sure that you agree that I'm not hiding anything important.